### PR TITLE
Alembic db_schema update

### DIFF
--- a/alembic/versions/219858383a66_rename_layout.py
+++ b/alembic/versions/219858383a66_rename_layout.py
@@ -1,0 +1,34 @@
+"""rename_layout
+
+Revision ID: 219858383a66
+Revises: f3c8db790f9e
+Create Date: 2022-10-13 14:24:29.935681
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '219858383a66'
+down_revision = 'f3c8db790f9e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+  op.alter_column('bn_config',
+                  'out_layout',
+                  new_column_name='in_layout',
+                  existing_type=sa.VARCHAR(60),
+                  nullable=False,
+                  server_default="NCHW")
+
+
+def downgrade() -> None:
+  op.alter_column('bn_config',
+                  'in_layout',
+                  new_column_name='out_layout',
+                  existing_type=sa.VARCHAR(60),
+                  nullable=False,
+                  server_default="NCHW")

--- a/alembic/versions/219858383a66_rename_layout.py
+++ b/alembic/versions/219858383a66_rename_layout.py
@@ -8,7 +8,6 @@ Create Date: 2022-10-13 14:24:29.935681
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = '219858383a66'
 down_revision = 'f3c8db790f9e'

--- a/alembic/versions/219858383a66_rename_layout.py
+++ b/alembic/versions/219858383a66_rename_layout.py
@@ -22,6 +22,8 @@ def upgrade() -> None:
                   existing_type=sa.VARCHAR(60),
                   nullable=False,
                   server_default="NCHW")
+  op.add_column('conv_config', sa.Column('driver', sa.String(512)))
+  op.add_column('bn_config', sa.Column('driver', sa.String(512)))
 
 
 def downgrade() -> None:
@@ -31,3 +33,5 @@ def downgrade() -> None:
                   existing_type=sa.VARCHAR(60),
                   nullable=False,
                   server_default="NCHW")
+  op.drop_column('conv_config', "driver")
+  op.drop_column('bn_config', "driver")


### PR DESCRIPTION
Renamed out_layout in bn_config to in_layout so we can take advantage of existing code from convolution and compose/decompose this tensor.

PR https://github.com/ROCmSoftwarePlatform/MITuna/pull/783 introduced this change, but the alembic part was missing.