### PR TITLE
Tuna-utility.py : code cleanup

### DIFF
--- a/tuna/utils/merge_db.py
+++ b/tuna/utils/merge_db.py
@@ -40,12 +40,7 @@ from tuna.metadata import DIR_MAP
 LOGGER = setup_logger('merge_pdb')
 
 DB_ALIAS = {'gfx803_36': 'gfx900_64', 'gfx803_64': 'gfx900_64'}
-
 SSH_TIMEOUT = 60.0  # in seconds
-SQLITE_REMOTE_TARGET_DB = 'miopen_1.0.0.udb'
-#  SQLITE_LOCAL_MERGE_DB = os.path.abspath(os.path.expanduser('miopen.db'))
-SQLITE_LOCAL_MERGE_DB = 'miopen.db'
-
 
 def parse_jobline(line):
   """get entries from a fdb text line """

--- a/tuna/utils/merge_db.py
+++ b/tuna/utils/merge_db.py
@@ -40,7 +40,7 @@ from tuna.metadata import DIR_MAP
 LOGGER = setup_logger('merge_pdb')
 
 DB_ALIAS = {'gfx803_36': 'gfx900_64', 'gfx803_64': 'gfx900_64'}
-SSH_TIMEOUT = 60.0  # in seconds
+
 
 def parse_jobline(line):
   """get entries from a fdb text line """

--- a/tuna/utils/utility.py
+++ b/tuna/utils/utility.py
@@ -118,4 +118,3 @@ def get_mmi_env_vars(env_vars={}):
     env_vars['gateway_user'] = None
 
   return env_vars
-

--- a/tuna/utils/utility.py
+++ b/tuna/utils/utility.py
@@ -47,24 +47,6 @@ def arch2targetid(arch):
   return targetid
 
 
-def get_filter_time(time_arr):
-  """Get filter time"""
-  rmid = len(time_arr) // 3
-  warm_times = time_arr[rmid:]
-  warm_mean = sum(warm_times) / len(warm_times)
-
-  variance = sum(
-      (pow(x_var - warm_mean, 2) for x_var in warm_times)) / len(warm_times)
-  std_dev = pow(variance, 1 / 2)
-  filter_warm = []
-  for time in warm_times:
-    if abs(time - warm_mean) <= std_dev:
-      filter_warm.append(time)
-  filter_mean = sum(filter_warm) / len(filter_warm)
-
-  return filter_mean
-
-
 def check_qts(hostname, logger=LOGGER):
   """find if hostname string has a local ip in qts"""
   if hostname in QTS_LIST:
@@ -137,9 +119,3 @@ def get_mmi_env_vars(env_vars={}):
 
   return env_vars
 
-
-class DotDict(dict):
-  """dot.notation access to dictionary attributes"""
-  __getattr__ = dict.get
-  __setattr__ = dict.__setitem__
-  __delattr__ = dict.__delitem__


### PR DESCRIPTION
MITunaX/tuna/utils/utils.py
Follwing unused functions and classes are removed.
1. def get_filter_time(time_arr):
2. class DotDict(dict):
MITunaX/tuna/utils/merge_db.py
 local unused variables removed.