### PR TITLE
tuna/utils folder added for pylint checks

### DIFF
--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -541,7 +541,8 @@ def runLint() {
           checkout scm
           def tuna_docker = docker.build("ci-tuna:${branch_id}", "--build-arg FIN_TOKEN=${FIN_TOKEN} .")
           tuna_docker.inside("") {
-            sh "cd tuna && pylint -f parseable --max-args=8 --ignore-imports=no --indent-string='  ' *.py miopen/*.py example/*.py"
+            sh "cd tuna && pylint -f parseable --max-args=8 --ignore-imports=no \
+            --indent-string='  ' *.py miopen/*.py example/*.py utils/*.py"
             sh "cd tuna && mypy analyze_parse_db.py"
             sh "cd tuna && mypy build_driver_cmd.py --ignore-missing-imports --follow-imports=skip"
           }


### PR DESCRIPTION
utils.grovvy - command upadated to enable the pylint checks.
pylint -f parseable --max-args=8 --ignore-imports=no --indent-string=' ' *.py miopen/*.py example/*.py utils/*.py
LWPTUNA219 - jira ticket ref.
