### PR TITLE
Post-tuning report

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==1.8.1
 asn1crypto==0.24.0
-astroid==2.14.2
+astroid==2.15.2
 attrs==19.3.0
 backcall==0.1.0
 bcrypt==3.1.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ opentelemetry-api==1.12.0rc2
 opentelemetry-distro==0.32b0
 opentelemetry-exporter-otlp-proto-http==1.11.1
 packaging==20.4
+pandas==1.5.3
 paramiko==2.10.1
 parso==0.3.1
 pathlib2==2.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==1.8.1
 asn1crypto==0.24.0
-astroid==2.14.2
+astroid==2.15.2
 attrs==19.3.0
 backcall==0.1.0
 bcrypt==3.1.4
@@ -50,7 +50,6 @@ sphinx_rtd_theme==0.5.2
 traitlets==4.3.2
 twine==4.0.2
 typed-ast==1.5.4
-types-paramiko==2.12.0.3
 types-PyYAML==6.0.12.6
 types-paramiko==3.0.0.4
 types-PyMySQL==1.0.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ markdown-it-py==2.2.0
 mccabe==0.6.1
 myst-parser==0.18.1
 more-itertools==8.3.0
-numpy==1.19.5
+numpy==1.24.2
 opentelemetry-api==1.12.0rc2
 opentelemetry-distro==0.32b0
 opentelemetry-exporter-otlp-proto-http==1.11.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -51,7 +51,6 @@ sphinx_rtd_theme==0.5.2
 traitlets==4.3.2
 twine==4.0.2
 typed-ast==1.5.4
-types-paramiko==2.12.0.3
 types-PyYAML==6.0.12.6
 types-paramiko==3.0.0.4
 types-PyMySQL==1.0.19.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 alembic==1.8.1
 asn1crypto==0.24.0
-astroid==2.15.2
+astroid==2.15.0
 attrs==19.3.0
 backcall==0.1.0
 bcrypt==3.1.4

--- a/tuna/miopen/scripts/report.py
+++ b/tuna/miopen/scripts/report.py
@@ -135,17 +135,17 @@ def configs_report(args, dfr):
   #remove entries where sess or gv dont have an entry for the same config
   dfr = dfr.loc[~dfr[['solver_x', 'solver_y']].isna().any(axis=1)].copy()
   #compute ktime diff for fastest solver/config
-  dfr['diff'] = dfr['ktime_x'] - dfr['ktime_y']
+  dfr['diff'] = dfr['ktime_y'] - dfr['ktime_x']
 
   #prct configs faster or slower
   prct_positive = (dfr['diff'] > 0).sum() / dfr.shape[0] * 100
   prct_equal = (dfr['diff'] == 0).sum() / dfr.shape[0] * 100
   prct_negative = (dfr['diff'] < 0).sum() / dfr.shape[0] * 100
   #pylint: disable=logging-format-truncated
-  LOGGER.info("configs with faster kernel_time: %f %%", round(prct_negative, 4))
+  LOGGER.info("configs with faster kernel_time: %f %%", round(prct_positive, 4))
   LOGGER.info("configs with equal kernel_time: %f %%", round(prct_equal, 4))
   LOGGER.info("configs with slower kernel_time: %f %% \n",
-              round(prct_positive, 4))
+              round(prct_negative, 4))
 
   #averages
   avg_positive = (dfr['diff'] > 0).mean()
@@ -155,7 +155,7 @@ def configs_report(args, dfr):
   LOGGER.info("Mean for configs with slower kernel_time: %s %%", avg_positive)
   LOGGER.info("Mean for all configs: %s %%", dfr['diff'].mean())
 
-  dfr['%speedup'] = (dfr['ktime_x'] - dfr['ktime_y']) / dfr['ktime_x'] * 100
+  dfr['%speedup'] = (dfr['ktime_y'] - dfr['ktime_x']) / dfr['ktime_y'] * 100
   LOGGER.info("Overall speed-up: %s %%", round(dfr['%speedup'].mean(), 4))
 
   config_data = f"config_data_sess{args.session_id}_gv{args.golden_v}.csv"
@@ -186,8 +186,8 @@ def solver_report(args, dfr):
   dfr_same_solvers = df_compare.loc[df_compare['solver_x'].eq(
       df_compare['solver_y'])]
   dfr_same_solvers = dfr_same_solvers.drop(columns=['idx_x', 'idx_y'])
-  dfr_same_solvers['%diff'] = (dfr_same_solvers['ktime_x'] - dfr_same_solvers['ktime_y'])\
-                    / dfr_same_solvers['ktime_x']  * 100
+  dfr_same_solvers['%diff'] = (dfr_same_solvers['ktime_y'] - dfr_same_solvers['ktime_x'])\
+                    / dfr_same_solvers['ktime_y']  * 100
   _, id_solver_map = get_id_solvers()
   dfr_same_solvers['solver_x'] = dfr_same_solvers['solver_x'].apply(
       id_solver_map.get)
@@ -202,8 +202,8 @@ def solver_report(args, dfr):
 
   #Percentage difference formula
   diff_mean = dfr_diff_solvers.groupby(['solver_x', 'solver_y'])\
-                  .apply(lambda grp: ((grp['ktime_x'] - grp['ktime_y'])
-                    / grp['ktime_x'] * 100 ).mean())
+                  .apply(lambda grp: ((grp['ktime_y'] - grp['ktime_x'])
+                    / grp['ktime_y'] * 100 ).mean())
   count = dfr_diff_solvers.groupby(['solver_x',
                                     'solver_y']).apply(lambda grp: grp.shape[0])
   # pylint: disable=unsupported-assignment-operation

--- a/tuna/miopen/scripts/report.py
+++ b/tuna/miopen/scripts/report.py
@@ -125,10 +125,10 @@ def summary_report(args, dbt):
   prct_equal = (dfr[6] == 0).sum() / dfr.shape[0] * 100
   prct_negative = (dfr[6] < 0).sum() / dfr.shape[0] * 100
   #pylint: disable=logging-format-truncated
-  LOGGER.info("configs with faster kernel_time: %f %%",
-              round(prct_negative, 4))
+  LOGGER.info("configs with faster kernel_time: %f %%", round(prct_negative, 4))
   LOGGER.info("configs with equal kernel_time: %f %%", round(prct_equal, 4))
-  LOGGER.info("configs with slower kernel_time: %f %% \n", round(prct_positive, 4))
+  LOGGER.info("configs with slower kernel_time: %f %% \n",
+              round(prct_positive, 4))
 
   #averages
   avg_positive = (dfr[6] > 0).mean()
@@ -138,7 +138,8 @@ def summary_report(args, dbt):
   LOGGER.info("Mean for all configs: %s %% \n", dfr[6].mean())
 
   prct_speedup_per_config = (dfr[2] - dfr[5]) / ((dfr[2] + dfr[5]) / 2) * 100
-  LOGGER.info("Overall speed-up: %s %%", round(prct_speedup_per_config.mean(), 4))
+  LOGGER.info("Overall speed-up: %s %%", round(prct_speedup_per_config.mean(),
+                                               4))
   speed_up = f"speed_up_sess{args.session_id}_gv{args.golden_v}.csv"
   LOGGER.info("Speed up per config has been written to file: %s", speed_up)
   prct_speedup_per_config.to_csv(speed_up)

--- a/tuna/miopen/scripts/report.py
+++ b/tuna/miopen/scripts/report.py
@@ -115,26 +115,26 @@ def summary_report(args, dbt):
 
   dfr[6] = dfr[5]-dfr[2]
   pd.options.display.max_rows = 100
-  print(dfr.tail(100))
+  #print(dfr.tail(100))
 
 
   #prct configs faster or slower
   prct_positive = (dfr[6] > 0).sum() / dfr.shape[0] *100
   prct_equal = (dfr[6] == 0).sum() / dfr.shape[0] *100
   prct_negative = (dfr[6] < 0).sum() / dfr.shape[0] *100
-  print(f"configs with faster kernel_time: {round(prct_positive,4)}%")
+  print(f"\nconfigs with faster kernel_time: {round(prct_positive,4)}%")
   print(f"configs with equal kernel_time: {round(prct_equal,4)}%")
   print(f"configs with slower kernel_time: {round(prct_negative,4)}%")
 
   #averages
   avg_positive = (dfr[6] > 0).mean()
   avg_negative = (dfr[6] < 0).mean()
-  print(f"Mean for configs with faster kernel_time: {avg_positive}")
+  print(f"\nMean for configs with faster kernel_time: {avg_positive}")
   print(f"Mean for configs with slower kernel_time: {avg_negative}")
   print(f"Mean for all configs: {dfr[6].mean()}")
 
   prct_speedup_per_config = (dfr[2]-dfr[5]) / ((dfr[2]+dfr[5]) /2) * 100
-  print(f"Overall speed-up: {round(prct_speedup_per_config.mean(), 4)}")
+  print(f"Overall speed-up: {round(prct_speedup_per_config.mean(), 4)}\n")
 
   return dfr
 
@@ -161,11 +161,9 @@ def detailed_report(args, dfr):
   _, id_solver_map = get_id_solvers()
   dfr_detailed_summary['solver_x'] = dfr_detailed_summary['solver_x'].apply(id_solver_map.get)
   dfr_detailed_summary['solver_y'] = dfr_detailed_summary['solver_y'].apply(id_solver_map.get)
-  #print(dfr_detailed_summary)
-  print("Detailed report has been written to file 'detailed_report.csv'")
-  dfr_detailed_summary.to_csv(f'detailed_report_sess{args.session_id}_gv{args.golden_v}.csv',\
-                              mode='a')
-  #dfr_detailed_summary.tail(100)
+  report_file = f"detailed_report_sess{args.session_id}_gv{args.golden_v}.csv"
+  print(f"Detailed report has been written to file: {report_file}")
+  dfr_detailed_summary.to_csv(report_file, mode='a')
 
 
 def main():

--- a/tuna/miopen/scripts/report.py
+++ b/tuna/miopen/scripts/report.py
@@ -26,8 +26,6 @@
 ###############################################################################
 """script for detecting find db entries with missing perf db entries"""
 
-from sqlalchemy import func
-
 import pandas as pd
 from tuna.parse_args import TunaArgs, setup_arg_parser
 from tuna.utils.logger import setup_logger
@@ -64,13 +62,14 @@ def parse_args():
 def get_data(args, dbt):
   """Get data from DB based on args.session_id and optional golden_v"""
 
+  with DbSession() as session:
     query = f"select t1.config as c1, t1.solver as s1, t1.kernel_time as k1,"\
             f"t2.config as c2, t2.solver as s2, t2.kernel_time as k2,"\
             f"t1.kernel_time-t2.kernel_time as diff from {dbt.find_db_table.__tablename__} t1 "\
             f"inner join (select config, solver, kernel_time, golden_miopen_v, session, "\
             f"arch, num_cu from conv_golden) t2 on t1.config=t2.config and t1.solver=t2.solver "\
-            f"inner join (select id, arch, num_cu from session) s1 on s1.id={args.session_id} where "\
-            f"t1.session={args.session_id} and t2.golden_miopen_v={args.golden_v} and "\
+            f"inner join (select id, arch, num_cu from session) s1 on s1.id={args.session_id} "\
+            f"where t1.session={args.session_id} and t2.golden_miopen_v={args.golden_v} and "\
             f"t2.arch=s1.arch and t2.num_cu=s1.num_cu order by t1.config"
 
     return pd.DataFrame(data=session.execute(query).fetchall())
@@ -85,14 +84,16 @@ def check_missing_configs(args, dbt):
     arch = sess[0].arch
     num_cu = sess[0].num_cu
 
-    query = f"select distinct config from {dbt.find_db_table.__tablename__} where id={args.session_id} "\
-            f"and config not in (select config from {dbt.golden_table.__tablename__} where "\
+    query = f"select distinct config from {dbt.find_db_table.__tablename__} "\
+            f"where id={args.session_id} and config not in "\
+            f"(select config from {dbt.golden_table.__tablename__} where "\
             f"golden_miopen_v={args.golden_v} and arch='{arch}' and num_cu={num_cu})"
     missing_configs = [x[0] for x in session.execute(query).fetchall()]
-    print_driver_cmds(missing_configs, "Missing commands")
+    print_driver_cmds(dbt, missing_configs, "Missing commands")
 
 
-def print_driver_cmds(ids_list, text):
+def print_driver_cmds(dbt, ids_list, text):
+  """Print configs present in session but missing from golden"""
   with DbSession() as session:
     query = session.query(dbt.config_table.driver)\
                    .filter(dbt.config_table.id.in_(ids_list))
@@ -103,81 +104,78 @@ def print_driver_cmds(ids_list, text):
 
 def summary_report(args, dbt):
   """Print tuning summary"""
-  df = get_data(args, dbt)
+  dfr = get_data(args, dbt)
 
-  #print(df.shape[0])
-  df_null = df.loc[df[[2, 5]].eq(-1).any(axis=1)].copy()
-  print(f"#configs with k_time=-1 in session_id={args.session_id}: {df_null[2].eq(-1).sum()}")
-  print(f"#configs with k_time=-1 in miopen_golden_v={args.golden_v}: {df_null[5].eq(-1).sum()}")
-  df = df.loc[~df[[2, 5]].eq(-1).any(axis=1)]
-  #df.to_csv('data.csv')
-  return df
-  #add summary for #configs with -1 k time
-  #print(df_null.shape[0])
-  #print(df.shape[0])
+  dfr_null = dfr.loc[dfr[[2, 5]].eq(-1).any(axis=1)].copy()
+  print(f"#configs with k_time=-1 in session_id={args.session_id}: {dfr_null[2].eq(-1).sum()}")
+  print(f"#configs with k_time=-1 in miopen_golden_v={args.golden_v}: {dfr_null[5].eq(-1).sum()}")
+  dfr = dfr.loc[~dfr[[2, 5]].eq(-1).any(axis=1)]
+  #dfr.to_csv('data.csv')
 
 
-  df[6] = df[5]-df[2]
+  dfr[6] = dfr[5]-dfr[2]
   pd.options.display.max_rows = 100
-  print(df.tail(100))
+  print(dfr.tail(100))
 
 
   #prct configs faster or slower
-  prct_positive = (df[6] > 0).sum() / df.shape[0] *100
-  prct_equal = (df[6] == 0).sum() / df.shape[0] *100
-  prct_negative = (df[6] < 0).sum() / df.shape[0] *100
+  prct_positive = (dfr[6] > 0).sum() / dfr.shape[0] *100
+  prct_equal = (dfr[6] == 0).sum() / dfr.shape[0] *100
+  prct_negative = (dfr[6] < 0).sum() / dfr.shape[0] *100
   print(f"configs with faster kernel_time: {round(prct_positive,4)}%")
   print(f"configs with equal kernel_time: {round(prct_equal,4)}%")
   print(f"configs with slower kernel_time: {round(prct_negative,4)}%")
 
   #averages
-  avg_positive = (df[6] > 0).mean()
-  avg_negative = (df[6] < 0).mean()
+  avg_positive = (dfr[6] > 0).mean()
+  avg_negative = (dfr[6] < 0).mean()
   print(f"Mean for configs with faster kernel_time: {avg_positive}")
   print(f"Mean for configs with slower kernel_time: {avg_negative}")
-  print(f"Mean for all configs: {df[6].mean()}")
+  print(f"Mean for all configs: {dfr[6].mean()}")
 
-  prct_speedup_per_config = (df[2]-df[5]) / ((df[2]+df[5]) /2) * 100
+  prct_speedup_per_config = (dfr[2]-dfr[5]) / ((dfr[2]+dfr[5]) /2) * 100
   print(f"Overall speed-up: {round(prct_speedup_per_config.mean(), 4)}")
 
-  return df
+  return dfr
 
-def detailed_report(args, dbt, df):
+def detailed_report(args, dfr):
   """Print detailed tuning analysis"""
-  #df = pd.read_csv('data.csv', index_col=0, header=0)
-  #df.columns = df.columns.map(int)
-  df_new = df.loc[:, 0:2]
-  df_old = df.loc[:, 3:5]
-  df_new.columns = df_old.columns = ['config', 'solver', 'ktime']
-  df_new_unq = df_new.loc[df_new.groupby('config')['ktime'].idxmin()]
-  df_old_unq = df_old.loc[df_old.groupby('config')['ktime'].idxmin()]
-  df_unq = df_new_unq.merge(df_old_unq, on='config')
-  df_diff = df_unq[df_unq['solver_x'] != df_unq['solver_y']]
+  #dfr = pd.read_csv('data.csv', index_col=0, header=0)
+  #dfr.columns = dfr.columns.map(int)
+  dfr_new = dfr.loc[:, 0:2]
+  dfr_old = dfr.loc[:, 3:5]
+  dfr_new.columns = dfr_old.columns = ['config', 'solver', 'ktime']
+  dfr_new_unq = dfr_new.loc[dfr_new.groupby('config')['ktime'].idxmin()]
+  dfr_old_unq = dfr_old.loc[dfr_old.groupby('config')['ktime'].idxmin()]
+  dfr_unq = dfr_new_unq.merge(dfr_old_unq, on='config')
+  dfr_diff = dfr_unq[dfr_unq['solver_x'] != dfr_unq['solver_y']]
 
-  #for key, grp in df_diff.groupby(['solver_x', 'solver_y']):
+  #for key, grp in dfr_diff.groupby(['solver_x', 'solver_y']):
   #  print(key, ((grp['ktime_y'] - grp['ktime_x']) / grp['ktime_x']).mean(), grp.shape[0])
 
-  diff_mean = df_diff.groupby(['solver_x', 'solver_y']).apply(lambda grp: ((grp['ktime_y'] - grp['ktime_x']) / grp['ktime_x']).mean())
-  count = df_diff.groupby(['solver_x', 'solver_y']).apply(lambda grp: grp.shape[0])
-  df_detailed_summary = pd.DataFrame({'diff_mean': diff_mean, 'count' : count}).reset_index()
+  diff_mean = dfr_diff.groupby(['solver_x', 'solver_y'])\
+                  .apply(lambda grp: ((grp['ktime_y'] - grp['ktime_x']) / grp['ktime_x']).mean())
+  count = dfr_diff.groupby(['solver_x', 'solver_y']).apply(lambda grp: grp.shape[0])
+  dfr_detailed_summary = pd.DataFrame({'diff_mean': diff_mean, 'count' : count}).reset_index()
 
   _, id_solver_map = get_id_solvers()
-  df_detailed_summary['solver_x'] = df_detailed_summary['solver_x'].apply(id_solver_map.get)
-  df_detailed_summary['solver_y'] = df_detailed_summary['solver_y'].apply(id_solver_map.get)
-  #print(df_detailed_summary)
+  dfr_detailed_summary['solver_x'] = dfr_detailed_summary['solver_x'].apply(id_solver_map.get)
+  dfr_detailed_summary['solver_y'] = dfr_detailed_summary['solver_y'].apply(id_solver_map.get)
+  #print(dfr_detailed_summary)
   print("Detailed report has been written to file 'detailed_report.csv'")
-  df_detailed_summary.to_csv('detailed_report_sess{args.session_id}_gv{args.golden_v}.csv', mode='a')
-  #df_detailed_summary.tail(100) 
-  
+  dfr_detailed_summary.to_csv(f'detailed_report_sess{args.session_id}_gv{args.golden_v}.csv',\
+                              mode='a')
+  #dfr_detailed_summary.tail(100)
+
 
 def main():
   """main"""
   args = parse_args()
   dbt = MIOpenDBTables(session_id=args.session_id, config_type=args.config_type)
 
-  #check_missing_configs(args, dbt)
-  df = summary_report(args, dbt)
-  detailed_report(args, dbt, df)
+  check_missing_configs(args, dbt)
+  dfr = summary_report(args, dbt)
+  detailed_report(args, dfr)
 
 
 if __name__ == '__main__':

--- a/tuna/miopen/scripts/report.py
+++ b/tuna/miopen/scripts/report.py
@@ -148,13 +148,15 @@ def detailed_report(args, dfr):
   dfr_new_unq = dfr_new.loc[dfr_new.groupby('config')['ktime'].idxmin()]
   dfr_old_unq = dfr_old.loc[dfr_old.groupby('config')['ktime'].idxmin()]
   dfr_unq = dfr_new_unq.merge(dfr_old_unq, on='config')
+  #NOTE: solver_x is session_id solver, solver_y is golden_v solver
   dfr_diff = dfr_unq[dfr_unq['solver_x'] != dfr_unq['solver_y']]
 
   #for key, grp in dfr_diff.groupby(['solver_x', 'solver_y']):
   #  print(key, ((grp['ktime_y'] - grp['ktime_x']) / grp['ktime_x']).mean(), grp.shape[0])
 
+  #Percentage difference formula
   diff_mean = dfr_diff.groupby(['solver_x', 'solver_y'])\
-                  .apply(lambda grp: ((grp['ktime_y'] - grp['ktime_x']) / grp['ktime_x']).mean())
+                  .apply(lambda grp: ((grp['ktime_y'] - grp['ktime_x']) / ((grp['ktime_y'] + grp['ktime_x'])/2) * 100 ).mean())
   count = dfr_diff.groupby(['solver_x', 'solver_y']).apply(lambda grp: grp.shape[0])
   dfr_detailed_summary = pd.DataFrame({'diff_mean': diff_mean, 'count' : count}).reset_index()
 
@@ -163,7 +165,8 @@ def detailed_report(args, dfr):
   dfr_detailed_summary['solver_y'] = dfr_detailed_summary['solver_y'].apply(id_solver_map.get)
   report_file = f"detailed_report_sess{args.session_id}_gv{args.golden_v}.csv"
   print(f"Detailed report has been written to file: {report_file}")
-  dfr_detailed_summary.to_csv(report_file, mode='a')
+  dfr_detailed_summary.rename(columns={'solver_x' : 'session_solver', 'solver_y' : 'golden_solver'}, inplace=True)
+  dfr_detailed_summary.to_csv(report_file)
 
 
 def main():

--- a/tuna/miopen/scripts/report.py
+++ b/tuna/miopen/scripts/report.py
@@ -26,21 +26,14 @@
 ###############################################################################
 """script for detecting find db entries with missing perf db entries"""
 
-import argparse
-import sqlite3
 from sqlalchemy import func
 
-import matplotlib.pyplot as plt
 import pandas as pd
 from tuna.parse_args import TunaArgs, setup_arg_parser
-from tuna.miopen.utils.parsing import parse_fdb_line
-from tuna.miopen.utils.analyze_parse_db import get_sqlite_table
-from tuna.miopen.driver.convolution import DriverConvolution
-from tuna.miopen.utils.helper import valid_cfg_dims
-from tuna.miopen.subcmd.import_db import get_cfg_driver
 from tuna.utils.logger import setup_logger
 from tuna.miopen.db.tables import MIOpenDBTables
 from tuna.dbBase.sql_alchemy import DbSession
+from tuna.utils.db_utility import get_id_solvers
 
 LOGGER = setup_logger('report')
 
@@ -59,6 +52,7 @@ def parse_args():
   )
   parser.add_argument('--golden_v',
                       dest='golden_v',
+                      required=True,
                       type=int,
                       default=None,
                       help='Target golden miopen version')
@@ -69,14 +63,6 @@ def parse_args():
 
 def get_data(args, dbt):
   """Get data from DB based on args.session_id and optional golden_v"""
-  golden_v = None
-  with DbSession() as session:
-    if args.golden_v is None:
-      query = session.query(func.max(dbt.golden_table.golden_miopen_v)) 
-      golden_v = session.execute(query).fetchone()[0]
-    else:
-      golden_v = args.golden_v
-      
 
     query = f"select t1.config as c1, t1.solver as s1, t1.kernel_time as k1,"\
             f"t2.config as c2, t2.solver as s2, t2.kernel_time as k2,"\
@@ -84,29 +70,114 @@ def get_data(args, dbt):
             f"inner join (select config, solver, kernel_time, golden_miopen_v, session, "\
             f"arch, num_cu from conv_golden) t2 on t1.config=t2.config and t1.solver=t2.solver "\
             f"inner join (select id, arch, num_cu from session) s1 on s1.id={args.session_id} where "\
-            f"t1.session={args.session_id} and t2.golden_miopen_v={golden_v} and "\
-            f"t2.arch=s1.arch and t2.num_cu=s1.num_cu"
-
-    #print(query)
+            f"t1.session={args.session_id} and t2.golden_miopen_v={args.golden_v} and "\
+            f"t2.arch=s1.arch and t2.num_cu=s1.num_cu order by t1.config"
 
     return pd.DataFrame(data=session.execute(query).fetchall())
 
+def check_missing_configs(args, dbt):
+  """Check for configs that are in the session tuning but not in the golden_v tuning"""
+  arch = None
+  num_cu=None
 
+  with DbSession() as session:
+    sess = session.query(dbt.session_table).filter(dbt.session_table.id==args.session_id).all()
+    arch = sess[0].arch
+    num_cu = sess[0].num_cu
+
+    query = f"select distinct config from {dbt.find_db_table.__tablename__} where id={args.session_id} "\
+            f"and config not in (select config from {dbt.golden_table.__tablename__} where "\
+            f"golden_miopen_v={args.golden_v} and arch='{arch}' and num_cu={num_cu})"
+    missing_configs = [x[0] for x in session.execute(query).fetchall()]
+    print_driver_cmds(missing_configs, "Missing commands")
+
+
+def print_driver_cmds(ids_list, text):
+  with DbSession() as session:
+    query = session.query(dbt.config_table.driver)\
+                   .filter(dbt.config_table.id.in_(ids_list))
+    drivers = [x[0] for x in query.all()]
+    print(f"{text}: {len(drivers)}")
+    for cfg in drivers:
+      print(cfg)
+
+def summary_report(args, dbt):
+  """Print tuning summary"""
+  df = get_data(args, dbt)
+
+  #print(df.shape[0])
+  df_null = df.loc[df[[2, 5]].eq(-1).any(axis=1)].copy()
+  print(f"#configs with k_time=-1 in session_id={args.session_id}: {df_null[2].eq(-1).sum()}")
+  print(f"#configs with k_time=-1 in miopen_golden_v={args.golden_v}: {df_null[5].eq(-1).sum()}")
+  df = df.loc[~df[[2, 5]].eq(-1).any(axis=1)]
+  #df.to_csv('data.csv')
+  return df
+  #add summary for #configs with -1 k time
+  #print(df_null.shape[0])
+  #print(df.shape[0])
+
+
+  df[6] = df[5]-df[2]
+  pd.options.display.max_rows = 100
+  print(df.tail(100))
+
+
+  #prct configs faster or slower
+  prct_positive = (df[6] > 0).sum() / df.shape[0] *100
+  prct_equal = (df[6] == 0).sum() / df.shape[0] *100
+  prct_negative = (df[6] < 0).sum() / df.shape[0] *100
+  print(f"configs with faster kernel_time: {round(prct_positive,4)}%")
+  print(f"configs with equal kernel_time: {round(prct_equal,4)}%")
+  print(f"configs with slower kernel_time: {round(prct_negative,4)}%")
+
+  #averages
+  avg_positive = (df[6] > 0).mean()
+  avg_negative = (df[6] < 0).mean()
+  print(f"Mean for configs with faster kernel_time: {avg_positive}")
+  print(f"Mean for configs with slower kernel_time: {avg_negative}")
+  print(f"Mean for all configs: {df[6].mean()}")
+
+  prct_speedup_per_config = (df[2]-df[5]) / ((df[2]+df[5]) /2) * 100
+  print(f"Overall speed-up: {round(prct_speedup_per_config.mean(), 4)}")
+
+  return df
+
+def detailed_report(args, dbt, df):
+  """Print detailed tuning analysis"""
+  #df = pd.read_csv('data.csv', index_col=0, header=0)
+  #df.columns = df.columns.map(int)
+  df_new = df.loc[:, 0:2]
+  df_old = df.loc[:, 3:5]
+  df_new.columns = df_old.columns = ['config', 'solver', 'ktime']
+  df_new_unq = df_new.loc[df_new.groupby('config')['ktime'].idxmin()]
+  df_old_unq = df_old.loc[df_old.groupby('config')['ktime'].idxmin()]
+  df_unq = df_new_unq.merge(df_old_unq, on='config')
+  df_diff = df_unq[df_unq['solver_x'] != df_unq['solver_y']]
+
+  #for key, grp in df_diff.groupby(['solver_x', 'solver_y']):
+  #  print(key, ((grp['ktime_y'] - grp['ktime_x']) / grp['ktime_x']).mean(), grp.shape[0])
+
+  diff_mean = df_diff.groupby(['solver_x', 'solver_y']).apply(lambda grp: ((grp['ktime_y'] - grp['ktime_x']) / grp['ktime_x']).mean())
+  count = df_diff.groupby(['solver_x', 'solver_y']).apply(lambda grp: grp.shape[0])
+  df_detailed_summary = pd.DataFrame({'diff_mean': diff_mean, 'count' : count}).reset_index()
+
+  _, id_solver_map = get_id_solvers()
+  df_detailed_summary['solver_x'] = df_detailed_summary['solver_x'].apply(id_solver_map.get)
+  df_detailed_summary['solver_y'] = df_detailed_summary['solver_y'].apply(id_solver_map.get)
+  #print(df_detailed_summary)
+  print("Detailed report has been written to file 'detailed_report.csv'")
+  df_detailed_summary.to_csv('detailed_report_sess{args.session_id}_gv{args.golden_v}.csv', mode='a')
+  #df_detailed_summary.tail(100) 
+  
 
 def main():
   """main"""
   args = parse_args()
   dbt = MIOpenDBTables(session_id=args.session_id, config_type=args.config_type)
-  df = get_data(args, dbt)
-  df[6] = df[5]-df[2]
 
-  prct_positive = (df[6] > 0).sum() / df.shape[0] *100
-  prct_equal = (df[6] == 0).sum() / df.shape[0] *100
-  prct_negative = (df[6] < 0).sum() / df.shape[0] *100
-
-  print(f"configs with faster kernel_time: {round(prct_positive,4)}%")
-  print(f"configs with equal kernel_time: {round(prct_equal,4)}%")
-  print(f"configs with slower kernel_time: {round(prct_negative,4)}%")
+  #check_missing_configs(args, dbt)
+  df = summary_report(args, dbt)
+  detailed_report(args, dbt, df)
 
 
 if __name__ == '__main__':

--- a/tuna/miopen/scripts/report.py
+++ b/tuna/miopen/scripts/report.py
@@ -26,8 +26,8 @@
 ###############################################################################
 """script for detecting find db entries with missing perf db entries"""
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from tuna.parse_args import TunaArgs, setup_arg_parser
 from tuna.utils.logger import setup_logger
 from tuna.miopen.db.tables import MIOpenDBTables
@@ -108,7 +108,8 @@ def print_driver_cmds(args, dbt, ids_list, text, table1):
     LOGGER.info("Driver cmds written to missing_%s.txt", table1)
     missing_drivers = []
     with open(f"missing_{table1}_sess{args.session_id}_gv{args.golden_v}.txt",
-              'w', encoding='utf-8') as fout:
+              'w',
+              encoding='utf-8') as fout:
       for entry in drivers:
         if entry[1] is not None:
           fout.write(f"{entry[1]}\n")

--- a/tuna/miopen/scripts/report.py
+++ b/tuna/miopen/scripts/report.py
@@ -98,6 +98,7 @@ def main():
   args = parse_args()
   dbt = MIOpenDBTables(session_id=args.session_id, config_type=args.config_type)
   df = get_data(args, dbt)
+  df[6] = df[5]-df[2]
 
   prct_positive = (df[6] > 0).sum() / df.shape[0] *100
   prct_equal = (df[6] == 0).sum() / df.shape[0] *100

--- a/tuna/miopen/subcmd/report.py
+++ b/tuna/miopen/subcmd/report.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+###############################################################################
+#
+# MIT License
+#
+# Copyright (c) 2023 Advanced Micro Devices, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+###############################################################################
+"""script for detecting find db entries with missing perf db entries"""
+
+import argparse
+import sqlite3
+from sqlalchemy import func
+
+from tuna.parse_args import TunaArgs, setup_arg_parser
+from tuna.miopen.utils.parsing import parse_fdb_line
+from tuna.miopen.utils.analyze_parse_db import get_sqlite_table
+from tuna.miopen.driver.convolution import DriverConvolution
+from tuna.miopen.utils.helper import valid_cfg_dims
+from tuna.miopen.subcmd.import_db import get_cfg_driver
+from tuna.utils.logger import setup_logger
+from tuna.miopen.db.tables import MIOpenDBTables
+from tuna.dbBase.sql_alchemy import DbSession
+
+LOGGER = setup_logger('analyze_fdb')
+
+
+def parse_args():
+  """command line parsing"""
+  parser = setup_arg_parser('DESC',
+                            [TunaArgs.CONFIG_TYPE])
+  parser.add_argument(
+      '--session_id',
+      required=True,
+      dest='session_id',
+      type=int,
+      help=
+      'Session id to be used for comaprison against golden_v'
+  )
+  parser.add_argument('--golden_v',
+                      dest='golden_v',
+                      type=int,
+                      default=None,
+                      help='Target golden miopen version')
+
+  args = parser.parse_args()
+  return args
+
+
+def get_data(args, dbt):
+  """Get data from DB based on args.session_id and optional golden_v"""
+  golden_v = None
+  with DbSession() as session:
+    #if args.golden_v is None:
+    query = session.query(func.max(dbt.golden_table.golden_miopen_v)) 
+    ret = session.execute(query)
+    print(ret[0])
+    exit()
+      
+
+    """ 
+    query = f"select t1.config as c1, t1.solver as s1, t1.kernel_time as k1,"\
+            f"t2.config as c2, t2.solver as s2, t2.kernel_time as k2,"\
+            f"t2.kernel_time-t1.kernel_time as diff from {dbt.find_db_table.__tablename__} t1"\
+            f"inner join (select config, solver, kernel_time, golden_miopen_v, session, "\
+            f"arch, num_cu, from conv_golden) t2 on t1.config=t2.config and t1.solver=t2.solver"\
+            f"inner join (select id, arch, num_cu from session) s1 on s1.id=91 where "\
+            f"t1.session={args.session_id} and t2.golden_miopen_v={golden_v} and "\
+            f"t2.arch=s1.arch and t2.num_cu=s1.num_cu"
+    #ret = session.execute(query)
+    """
+
+
+
+def main():
+  """main"""
+  args = parse_args()
+  dbt = MIOpenDBTables(session_id=args.session_id, config_type=args.config_type)
+  get_data(args, dbt)
+
+
+if __name__ == '__main__':
+  main()

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -547,6 +547,7 @@ def runLint() {
           def tuna_docker = docker.build("ci-tuna:${branch_id}", "--build-arg FIN_TOKEN=${FIN_TOKEN} .")
           tuna_docker.inside("") {
             sh "cd tuna && pylint -f parseable --max-args=8 --ignore-imports=no --indent-string='  ' *.py miopen/*.py example/*.py"
+            sh "cd tuna && find miopen/scripts/ -type f -name '*.py' | xargs pylint -f parseable --max-args=8 --ignore-imports=no --indent-string='  '"
             sh "mypy tuna/miopen/utils/config_type.py"
             sh "mypy tuna/connection.py --ignore-missing-imports"
             sh "mypy tuna/miopen/utils/analyze_parse_db.py --ignore-missing-imports"


### PR DESCRIPTION
Post tuning report sample:
```

~/MITuna/tuna/miopen/scripts$ ./report.py --session_id 92 --golden_v 12
2023-03-24 12:50:29,920 - report - INFO -  [report.py:109] - Missing commands from session:  2
2023-03-24 12:50:29,920 - report - INFO -  [report.py:110] - Driver cmds written to missing_session.txt
2023-03-24 12:50:30,920 - report - INFO -  [report.py:109] - Missing commands from conv_golden:  12226
2023-03-24 12:50:30,920 - report - INFO -  [report.py:110] - Driver cmds written to missing_conv_golden.txt
2023-03-24 12:50:30,921 - report - WARNING -  [report.py:119] - Configs with missing drivers in db: 12126
2023-03-24 12:50:30,934 - report - INFO -  [report.py:131] - #configs with k_time=-1 in session_id= 92: 291
2023-03-24 12:50:30,935 - report - INFO -  [report.py:133] - #configs with k_time=-1 in miopen_golden_v=12 : 90
2023-03-24 12:50:31,315 - report - INFO -  [report.py:148] - configs with faster kernel_time: 0.295900 %
2023-03-24 12:50:31,315 - report - INFO -  [report.py:149] - configs with equal kernel_time: 0.000000 %
2023-03-24 12:50:31,315 - report - INFO -  [report.py:150] - configs with slower kernel_time: 0.161300 %

2023-03-24 12:50:31,316 - report - INFO -  [report.py:156] - Mean for configs with faster kernel_time: 0.0029589504336662805 %
2023-03-24 12:50:31,316 - report - INFO -  [report.py:157] - Mean for configs with slower kernel_time: 0.001612549707236121 %
2023-03-24 12:50:31,317 - report - INFO -  [report.py:158] - Mean for all configs: -0.8510265479452053 %
2023-03-24 12:50:31,318 - report - INFO -  [report.py:161] - Overall speed-up: 0.4914 %
2023-03-24 12:50:31,318 - report - INFO -  [report.py:164] - Speed-up per config has been written to file: speed_up_sess92_gv12.csv
2023-03-24 12:50:31,409 - report - INFO -  [report.py:168] - Raw DB data has been written to file: db_data_sess92_gv12.csv

2023-03-24 12:50:31,553 - report - INFO -  [report.py:176] - Detailed solver report:
2023-03-24 12:50:36,148 - report - INFO -  [report.py:194] - Mean %change for same solver: -5.047869798809325
2023-03-24 12:50:36,148 - report - INFO -  [report.py:196] - Same solvers detailed report has been written to file: same_solvers_report_sess92_gv12.csv
2023-03-24 12:50:36,175 - report - INFO -  [report.py:217] - Mean %change for the solvers that have changed: -25.357020533588024
2023-03-24 12:50:36,175 - report - INFO -  [report.py:219] - Diff solvers detailed report has been written to file: different_solvers_report_sess92_gv12.csv


```


