### PR TITLE
layout length checking for config import

### DIFF
--- a/tuna/miopen/driver/convolution.py
+++ b/tuna/miopen/driver/convolution.py
@@ -208,6 +208,11 @@ class DriverConvolution(DriverBase):
           LOGGER.warning("Using default for key %s, because spatial_dim is %s.",
                          k, self.spatial_dim)
 
+    if self.spatial_dim == 3 and len(self.out_layout) != 5:
+        raise ValueError("Layout string (%s) should be 5 characters for spatial_dim %s", self.out_layout, self.spatial_dim)
+    elif self.spatial_dim == 2 and len(self.out_layout) != 4:
+        raise ValueError("Layout string (%s) should be 4 characters for spatial_dim %s", self.out_layout, self.spatial_dim)
+
   @staticmethod
   def get_params(tok1: str) -> str:
     """Get full arg name"""

--- a/tuna/miopen/driver/convolution.py
+++ b/tuna/miopen/driver/convolution.py
@@ -210,11 +210,13 @@ class DriverConvolution(DriverBase):
 
     if self.spatial_dim == 3 and len(self.out_layout) != 5:
       raise ValueError(
-          f"Layout string {self.out_layout} should be 5 characters for spatial_dim {self.spatial_dim}"
+          f"Layout string {self.out_layout} should be 5 characters"\
+          f" for spatial_dim {self.spatial_dim}"
       )
     if self.spatial_dim == 2 and len(self.out_layout) != 4:
       raise ValueError(
-          f"Layout string {self.out_layout} should be 4 characters for spatial_dim {self.spatial_dim}"
+          f"Layout string {self.out_layout} should be 4 characters"\
+          f" for spatial_dim {self.spatial_dim}"
       )
 
   @staticmethod

--- a/tuna/miopen/driver/convolution.py
+++ b/tuna/miopen/driver/convolution.py
@@ -210,12 +210,12 @@ class DriverConvolution(DriverBase):
 
     if self.spatial_dim == 3 and len(self.out_layout) != 5:
       raise ValueError(
-          "Layout string (%s) should be 5 characters for spatial_dim %s",
-          self.out_layout, self.spatial_dim)
-    elif self.spatial_dim == 2 and len(self.out_layout) != 4:
+          f"Layout string {self.out_layout} should be 5 characters for spatial_dim {self.spatial_dim}"
+      )
+    if self.spatial_dim == 2 and len(self.out_layout) != 4:
       raise ValueError(
-          "Layout string (%s) should be 4 characters for spatial_dim %s",
-          self.out_layout, self.spatial_dim)
+          f"Layout string {self.out_layout} should be 4 characters for spatial_dim {self.spatial_dim}"
+      )
 
   @staticmethod
   def get_params(tok1: str) -> str:

--- a/tuna/miopen/driver/convolution.py
+++ b/tuna/miopen/driver/convolution.py
@@ -209,9 +209,13 @@ class DriverConvolution(DriverBase):
                          k, self.spatial_dim)
 
     if self.spatial_dim == 3 and len(self.out_layout) != 5:
-        raise ValueError("Layout string (%s) should be 5 characters for spatial_dim %s", self.out_layout, self.spatial_dim)
+      raise ValueError(
+          "Layout string (%s) should be 5 characters for spatial_dim %s",
+          self.out_layout, self.spatial_dim)
     elif self.spatial_dim == 2 and len(self.out_layout) != 4:
-        raise ValueError("Layout string (%s) should be 4 characters for spatial_dim %s", self.out_layout, self.spatial_dim)
+      raise ValueError(
+          "Layout string (%s) should be 4 characters for spatial_dim %s",
+          self.out_layout, self.spatial_dim)
 
   @staticmethod
   def get_params(tok1: str) -> str:


### PR DESCRIPTION
Adds a check in the config driver which will raise an error when the layout string for a config is not the proper length indicated by its spatial_dim.