### PR TITLE
Fix DeclarativeMeta

### DIFF
--- a/tuna/dbBase/base_class.py
+++ b/tuna/dbBase/base_class.py
@@ -27,7 +27,7 @@
 """ Module for creating DB tables interfaces"""
 from typing import Dict, Any, List
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.ext.declarative.api import DeclarativeMeta
+from sqlalchemy.ext.declarative import DeclarativeMeta
 from sqlalchemy.sql import func as sqla_func
 from sqlalchemy.dialects.mysql import TINYINT
 from sqlalchemy import Column, Integer, DateTime, text


### PR DESCRIPTION
Fix: `no module named 'sqlalchemy.ext.declarative.api'`.

To reproduce, run: `./MITuna/tuna/miopen/subcmd/load_job.py --help`