### PR TITLE
Export script & fdb key parsing fixes

### DIFF
--- a/tests/test_export_db.py
+++ b/tests/test_export_db.py
@@ -217,12 +217,12 @@ def test_get_sqlite_cfg_dict():
   assert cfg_dict['pad_d'] == 0
   assert cfg_dict['pad_h'] == 1
   assert cfg_dict['pad_w'] == 1
-  assert cfg_dict['dilation_d'] == 1
-  assert cfg_dict['dilation_h'] == 1
-  assert cfg_dict['dilation_w'] == 1
   assert cfg_dict['conv_stride_d'] == 1
   assert cfg_dict['conv_stride_h'] == 1
   assert cfg_dict['conv_stride_w'] == 1
+  assert cfg_dict['dilation_d'] == 1
+  assert cfg_dict['dilation_h'] == 1
+  assert cfg_dict['dilation_w'] == 1
   assert cfg_dict['in_layout'] == 'NCDHW'
   assert cfg_dict['out_layout'] == 'NCDHW'
   assert cfg_dict['fil_layout'] == 'NCDHW'
@@ -248,12 +248,12 @@ def test_get_sqlite_cfg_dict():
   assert cfg_dict['pad_d'] == 13
   assert cfg_dict['pad_h'] == 14
   assert cfg_dict['pad_w'] == 15
-  assert cfg_dict['dilation_d'] == 16
-  assert cfg_dict['dilation_h'] == 17
-  assert cfg_dict['dilation_w'] == 18
-  assert cfg_dict['conv_stride_d'] == 19
-  assert cfg_dict['conv_stride_h'] == 20
-  assert cfg_dict['conv_stride_w'] == 21
+  assert cfg_dict['conv_stride_d'] == 16
+  assert cfg_dict['conv_stride_h'] == 17
+  assert cfg_dict['conv_stride_w'] == 18
+  assert cfg_dict['dilation_d'] == 19
+  assert cfg_dict['dilation_h'] == 20
+  assert cfg_dict['dilation_w'] == 21
   assert cfg_dict['in_layout'] == 'NCDHW'
   assert cfg_dict['out_layout'] == 'NCDHW'
   assert cfg_dict['fil_layout'] == 'NCDHW'
@@ -279,12 +279,12 @@ def test_get_sqlite_cfg_dict():
   assert cfg_dict['pad_d'] == 13
   assert cfg_dict['pad_h'] == 14
   assert cfg_dict['pad_w'] == 15
-  assert cfg_dict['dilation_d'] == 16
-  assert cfg_dict['dilation_h'] == 17
-  assert cfg_dict['dilation_w'] == 18
-  assert cfg_dict['conv_stride_d'] == 19
-  assert cfg_dict['conv_stride_h'] == 20
-  assert cfg_dict['conv_stride_w'] == 21
+  assert cfg_dict['conv_stride_d'] == 16
+  assert cfg_dict['conv_stride_h'] == 17
+  assert cfg_dict['conv_stride_w'] == 18
+  assert cfg_dict['dilation_d'] == 19
+  assert cfg_dict['dilation_h'] == 20
+  assert cfg_dict['dilation_w'] == 21
   assert cfg_dict['in_layout'] == 'NCDHW'
   assert cfg_dict['out_layout'] == 'NCDHW'
   assert cfg_dict['fil_layout'] == 'NCDHW'

--- a/tests/test_export_db.py
+++ b/tests/test_export_db.py
@@ -43,7 +43,8 @@ from tuna.miopen.subcmd.export_db import (get_filename, get_base_query,
                                           build_miopen_fdb, write_fdb,
                                           export_fdb, build_miopen_kdb,
                                           insert_perf_db_sqlite,
-                                          create_sqlite_tables, get_cfg_dict)
+                                          create_sqlite_tables)
+from tuna.miopen.utils.analyze_parse_db import get_sqlite_cfg_dict
 from tuna.utils.db_utility import DB_Type
 from tuna.miopen.db.tables import MIOpenDBTables, ConfigType
 from tuna.dbBase.sql_alchemy import DbSession
@@ -168,18 +169,126 @@ def test_insert_perf_db_sqlite():
   ), f"expected inserted data {tuple(itertools.islice(expected_data.values(),2))}, but got {inserted_data}"
 
 
-def test_get_cfg_dict():
+def test_get_sqlite_cfg_dict():
+  fdb_key = '1-161-700-5x20-32-81-350-2-2x9-2x2-1x1-0-NCHW-BF16-F'
+  cfg_dict = get_sqlite_cfg_dict(fdb_key)
 
-  cfg_entry = CfgEntry()
-  tensor_entry = TensorEntry()
+  assert cfg_dict['spatial_dim'] == 2
+  assert cfg_dict['in_channels'] == 1
+  assert cfg_dict['in_h'] == 161
+  assert cfg_dict['in_w'] == 700
+  assert cfg_dict['fil_h'] == 5
+  assert cfg_dict['fil_w'] == 20
+  assert cfg_dict['out_channels'] == 32
 
-  cfg_dict = get_cfg_dict(cfg_entry, tensor_entry)
+  assert cfg_dict['batchsize'] == 2
+  assert cfg_dict['pad_h'] == 2
+  assert cfg_dict['pad_w'] == 9
+  assert cfg_dict['conv_stride_h'] == 2
+  assert cfg_dict['conv_stride_w'] == 2
+  assert cfg_dict['dilation_h'] == 1
+  assert cfg_dict['dilation_w'] == 1
+  assert cfg_dict['in_layout'] == 'NCHW'
+  assert cfg_dict['out_layout'] == 'NCHW'
+  assert cfg_dict['fil_layout'] == 'NCHW'
+  assert cfg_dict['group_count'] == 1
+  assert cfg_dict['direction'] == 'F'
+  assert cfg_dict['layout'] == 'NCHW'
+  assert cfg_dict['data_type'] == 'BF16'
+  assert cfg_dict['bias'] == 0
 
-  assert isinstance(cfg_dict, dict)
-  assert 'tensor_id_1' in cfg_dict
-  assert 'tensor_id_2' in cfg_dict
-  assert cfg_dict['tensor_id_1'] == 'cfg_value_1'
-  assert cfg_dict['tensor_id_2'] == 'cfg_value_2'
+  fdb_key = '1024-1-14-14-1x3x3-1024-1-14-14-128-0x1x1-1x1x1-1x1x1-0-NCDHW-FP32-W_g32'
+  cfg_dict = get_sqlite_cfg_dict(fdb_key)
+
+  assert cfg_dict['in_channels'] == 1024
+  assert cfg_dict['in_d'] == 1
+  assert cfg_dict['in_h'] == 14
+  assert cfg_dict['in_w'] == 14
+  assert cfg_dict['fil_d'] == 1
+  assert cfg_dict['fil_h'] == 3
+  assert cfg_dict['fil_w'] == 3
+  assert cfg_dict['out_channels'] == 1024
+
+  assert cfg_dict['batchsize'] == 128
+  assert cfg_dict['pad_d'] == 0
+  assert cfg_dict['pad_h'] == 1
+  assert cfg_dict['pad_w'] == 1
+  assert cfg_dict['dilation_d'] == 1
+  assert cfg_dict['dilation_h'] == 1
+  assert cfg_dict['dilation_w'] == 1
+  assert cfg_dict['conv_stride_d'] == 1
+  assert cfg_dict['conv_stride_h'] == 1
+  assert cfg_dict['conv_stride_w'] == 1
+  assert cfg_dict['in_layout'] == 'NCDHW'
+  assert cfg_dict['out_layout'] == 'NCDHW'
+  assert cfg_dict['fil_layout'] == 'NCDHW'
+  assert cfg_dict['group_count'] == 32
+  assert cfg_dict['direction'] == 'W'
+  assert cfg_dict['layout'] == 'NCDHW'
+  assert cfg_dict['data_type'] == 'FP32'
+  assert cfg_dict['bias'] == 0
+
+  fdb_key = '1-2-3-4-5x6x7-8-9-10-11-12-13x14x15-16x17x18-19x20x21-22-NCDHW-FP32-W_g32'
+  cfg_dict = get_sqlite_cfg_dict(fdb_key)
+
+  assert cfg_dict['in_channels'] == 1
+  assert cfg_dict['in_d'] == 2
+  assert cfg_dict['in_h'] == 3
+  assert cfg_dict['in_w'] == 4
+  assert cfg_dict['fil_d'] == 5
+  assert cfg_dict['fil_h'] == 6
+  assert cfg_dict['fil_w'] == 7
+  assert cfg_dict['out_channels'] == 8
+
+  assert cfg_dict['batchsize'] == 12
+  assert cfg_dict['pad_d'] == 13
+  assert cfg_dict['pad_h'] == 14
+  assert cfg_dict['pad_w'] == 15
+  assert cfg_dict['dilation_d'] == 16
+  assert cfg_dict['dilation_h'] == 17
+  assert cfg_dict['dilation_w'] == 18
+  assert cfg_dict['conv_stride_d'] == 19
+  assert cfg_dict['conv_stride_h'] == 20
+  assert cfg_dict['conv_stride_w'] == 21
+  assert cfg_dict['in_layout'] == 'NCDHW'
+  assert cfg_dict['out_layout'] == 'NCDHW'
+  assert cfg_dict['fil_layout'] == 'NCDHW'
+  assert cfg_dict['group_count'] == 32
+  assert cfg_dict['direction'] == 'W'
+  assert cfg_dict['layout'] == 'NCDHW'
+  assert cfg_dict['data_type'] == 'FP32'
+  assert cfg_dict['bias'] == 0
+
+  fdb_key = '1-2-3-4-5x6x7-8-9-10-11-12-13x14x15-16x17x18-19x20x21-22-NCDHW-FP32-F'
+  cfg_dict = get_sqlite_cfg_dict(fdb_key)
+
+  assert cfg_dict['in_channels'] == 1
+  assert cfg_dict['in_d'] == 2
+  assert cfg_dict['in_h'] == 3
+  assert cfg_dict['in_w'] == 4
+  assert cfg_dict['fil_d'] == 5
+  assert cfg_dict['fil_h'] == 6
+  assert cfg_dict['fil_w'] == 7
+  assert cfg_dict['out_channels'] == 8
+
+  assert cfg_dict['batchsize'] == 12
+  assert cfg_dict['pad_d'] == 13
+  assert cfg_dict['pad_h'] == 14
+  assert cfg_dict['pad_w'] == 15
+  assert cfg_dict['dilation_d'] == 16
+  assert cfg_dict['dilation_h'] == 17
+  assert cfg_dict['dilation_w'] == 18
+  assert cfg_dict['conv_stride_d'] == 19
+  assert cfg_dict['conv_stride_h'] == 20
+  assert cfg_dict['conv_stride_w'] == 21
+  assert cfg_dict['in_layout'] == 'NCDHW'
+  assert cfg_dict['out_layout'] == 'NCDHW'
+  assert cfg_dict['fil_layout'] == 'NCDHW'
+  assert cfg_dict['group_count'] == 1
+  assert cfg_dict['direction'] == 'F'
+  assert cfg_dict['layout'] == 'NCDHW'
+  assert cfg_dict['data_type'] == 'FP32'
+  assert cfg_dict['bias'] == 0
 
 
 def test_export_db():

--- a/tests/test_export_db.py
+++ b/tests/test_export_db.py
@@ -69,6 +69,10 @@ if args.session_id:
   args.arch = dbt.session.arch
   args.num_cu = dbt.session.num_cu
 
+args.src_table = dbt.find_db_table
+if args.golden_v is not None:
+  args.src_table = dbt.golden_table
+
 logger = logging.getLogger("test_logger")
 
 

--- a/tuna/miopen/subcmd/export_db.py
+++ b/tuna/miopen/subcmd/export_db.py
@@ -243,8 +243,6 @@ def build_miopen_kdb(dbt: MIOpenDBTables, find_db, logger: logging.Logger):
       query = session.query(dbt.kernel_cache)\
           .filter(dbt.kernel_cache.kernel_group == fastest_slv.kernel_group)\
           .filter(dbt.kernel_cache.valid == 1)
-      #logger.warning("adding fdb_key:%s, config:%s, solver:%s, kernel groups: %s",
-      #fdb_key, fastest_slv.config, fastest_slv.solver, fastest_slv.kernel_group)
       for kinder in query.all():
         num_kdb_blobs += 1
         kern_db.append(kinder)

--- a/tuna/miopen/subcmd/export_db.py
+++ b/tuna/miopen/subcmd/export_db.py
@@ -39,12 +39,9 @@ from tuna.miopen.db.miopen_tables import GoldenMixin
 from tuna.miopen.db.tables import MIOpenDBTables
 from tuna.miopen.utils.metadata import SQLITE_PERF_DB_COLS
 from tuna.utils.db_utility import get_id_solvers, DB_Type
-from tuna.utils.utility import arch2targetid
 from tuna.utils.logger import setup_logger
 from tuna.miopen.utils.analyze_parse_db import get_config_sqlite, insert_solver_sqlite
-from tuna.miopen.utils.analyze_parse_db import mysql_to_sqlite_cfg
-from tuna.miopen.utils.parsing import parse_pdb_key
-from tuna.miopen.worker.fin_utils import compose_config_obj
+from tuna.miopen.utils.analyze_parse_db import get_sqlite_cfg_dict
 from tuna.miopen.parse_miopen_args import get_export_db_parser
 
 DIR_NAME = {'F': 'Fwd', 'B': 'BwdData', 'W': 'BwdWeights'}
@@ -94,27 +91,23 @@ def get_filename(arch: str,
 def get_base_query(dbt: MIOpenDBTables, args: argparse.Namespace,
                    logger: logging.Logger):
   """ general query for fdb/pdb results """
-  src_table = dbt.find_db_table
-  if args.golden_v is not None:
-    src_table = dbt.golden_table
-
   with DbSession() as session:
-    query = session.query(src_table, dbt.config_table)
+    query = session.query(args.src_table, dbt.config_table)
     if args.golden_v is not None:
-      query = query.filter(src_table.golden_miopen_v == args.golden_v)\
-              .filter(src_table.arch == args.arch)
+      query = query.filter(args.src_table.golden_miopen_v == args.golden_v)\
+              .filter(args.src_table.arch == args.arch)
       if args.num_cu:
-        query = query.filter(src_table.num_cu == args.num_cu)
+        query = query.filter(args.src_table.num_cu == args.num_cu)
       logger.info("golden_miopen_v: %s, arch: %s, num_cu: %s", args.golden_v,
                   args.arch, args.num_cu)
     else:
-      query = query.filter(src_table.session == dbt.session.id)
+      query = query.filter(args.src_table.session == dbt.session.id)
       logger.info("rocm_v : %s", dbt.session.rocm_v)
       logger.info("miopen_v : %s", dbt.session.miopen_v)
 
-    query = query.filter(src_table.valid == 1)\
-        .filter(src_table.opencl == args.opencl)\
-        .filter(src_table.config == dbt.config_table.id)
+    query = query.filter(args.src_table.valid == 1)\
+        .filter(args.src_table.opencl == args.opencl)\
+        .filter(args.src_table.config == dbt.config_table.id)
 
     if args.config_tag:
       logger.info("config_tag : %s", args.config_tag)
@@ -128,19 +121,17 @@ def get_fdb_query(dbt: MIOpenDBTables, args: argparse.Namespace,
                   logger: logging.Logger):
   """ Helper function to create find db query
   """
-  src_table = dbt.find_db_table
-  if args.golden_v is not None:
-    src_table = dbt.golden_table
-
   query = get_base_query(dbt, args, logger)
-  query = query.filter(src_table.kernel_time != -1)\
-      .filter(src_table.workspace_sz != -1)
+  query = query.filter(args.src_table.kernel_time != -1)\
+      .filter(args.src_table.workspace_sz != -1)
 
-  if src_table == dbt.golden_table:
-    query = query.order_by(src_table.fdb_key, src_table.update_ts.desc(),
-                           src_table.num_cu.asc())
+  if args.src_table == dbt.golden_table:
+    query = query.order_by(args.src_table.fdb_key,
+                           args.src_table.update_ts.desc(),
+                           args.src_table.num_cu.asc())
   else:
-    query = query.order_by(src_table.fdb_key, src_table.update_ts.desc())
+    query = query.order_by(args.src_table.fdb_key,
+                           args.src_table.update_ts.desc())
 
   return query
 
@@ -148,13 +139,9 @@ def get_fdb_query(dbt: MIOpenDBTables, args: argparse.Namespace,
 def get_pdb_query(dbt: MIOpenDBTables, args: argparse.Namespace,
                   logger: logging.Logger):
   """Compose query to get perf_db rows based on filters from args"""
-  src_table = dbt.find_db_table
-  if args.golden_v is not None:
-    src_table = dbt.golden_table
-
   query = get_fdb_query(dbt, args, logger)
-  query = query.filter(src_table.params != '')\
-      .filter(src_table.solver == dbt.solver_table.id)\
+  query = query.filter(args.src_table.params != '')\
+      .filter(args.src_table.solver == dbt.solver_table.id)\
       .filter(dbt.solver_table.tunable == 1)
 
   return query
@@ -181,7 +168,7 @@ def add_entry_to_solvers(fdb_entry: Union[GoldenMixin, FindDBMixin],
   return True
 
 
-def build_miopen_fdb(query, logger):
+def build_miopen_fdb(query, logger: logging.Logger) -> OrderedDict:
   """return dict with key: fdb_key + alg_lib, val: solver list"""
   find_db: OrderedDict = OrderedDict()
   solvers: Dict[str, Dict[str, Any]] = {}
@@ -256,6 +243,7 @@ def build_miopen_kdb(dbt: MIOpenDBTables, find_db, logger: logging.Logger):
       query = session.query(dbt.kernel_cache)\
           .filter(dbt.kernel_cache.kernel_group == fastest_slv.kernel_group)\
           .filter(dbt.kernel_cache.valid == 1)
+      #logger.warning("adding fdb_key:%s, config:%s, solver:%s, kernel groups: %s", fdb_key, fastest_slv.config, fastest_slv.solver, fastest_slv.kernel_group)
       for kinder in query.all():
         num_kdb_blobs += 1
         kern_db.append(kinder)
@@ -287,7 +275,6 @@ def write_kdb(arch, num_cu, kern_db, logger: logging.Logger, filename=None):
       "CREATE UNIQUE INDEX `idx_kern_db` ON kern_db(kernel_name, kernel_args);")
 
   ins_list = []
-  arch_ext = arch2targetid(arch)
   for kern in kern_db:
     name = kern.kernel_name
     args = kern.kernel_args
@@ -296,7 +283,7 @@ def write_kdb(arch, num_cu, kern_db, logger: logging.Logger, filename=None):
       name += ".o"
     if not "-mcpu=" in args:
       if not name.endswith('.mlir.o'):
-        args += f" -mcpu={arch_ext}"
+        args += f" -mcpu={arch}"
 
     ins_key = (name, args)
     if ins_key not in ins_list:
@@ -315,13 +302,34 @@ def write_kdb(arch, num_cu, kern_db, logger: logging.Logger, filename=None):
   return file_name
 
 
-def export_kdb(dbt: MIOpenDBTables, args: argparse.Namespace,
-               logger: logging.Logger):
+def export_kdb(dbt: MIOpenDBTables,
+               args: argparse.Namespace,
+               logger: logging.Logger,
+               skew_fdbs=True):
   """
   Function to export the kernel cache
   """
   query = get_fdb_query(dbt, args, logger)
-  miopen_fdb = build_miopen_fdb(query, logger)
+
+  miopen_fdb: OrderedDict = OrderedDict()
+  if skew_fdbs and not args.num_cu:
+    with DbSession() as session:
+      db_entries = query.all()
+      fdb_ids = []
+      for fdb_entry, _ in db_entries:
+        fdb_ids.append(fdb_entry.id)
+
+      skews = [int(x[0]) for x in session.query(args.src_table.num_cu).distinct()\
+                .filter(args.src_table.id.in_(fdb_ids)).all()]
+      logger.info("skews %s", skews)
+
+    for num_cu in skews:
+      cu_query = query.filter(args.src_table.num_cu == num_cu)
+      miopen_fdb_skew = build_miopen_fdb(cu_query, logger)
+      for key, value in miopen_fdb_skew.items():
+        miopen_fdb[f"{key}_cu{num_cu}"] = value
+  else:
+    miopen_fdb = build_miopen_fdb(query, logger)
 
   logger.info("Building kdb.")
   kern_db = build_miopen_kdb(dbt, miopen_fdb, logger)
@@ -363,23 +371,6 @@ def create_sqlite_tables(arch, num_cu, filename=None):
   cur.close()
   cnx.commit()
   return cnx, local_path
-
-
-def get_cfg_dict(cfg_entry, tensor_entry):
-  """compose config_dict"""
-  cfg_dict = compose_config_obj(cfg_entry)
-
-  if cfg_entry.valid == 1:
-    cfg_dict = mysql_to_sqlite_cfg(cfg_dict)
-
-  ext_dict = tensor_entry.to_dict(ommit_valid=True)
-  ext_dict.pop('id')
-  cfg_dict.update(ext_dict)
-
-  #bias is always 0
-  cfg_dict['bias'] = 0
-
-  return dict(cfg_dict)
 
 
 def insert_perf_db_sqlite(cnx, perf_db_entry, ins_cfg_id):
@@ -424,15 +415,7 @@ def populate_sqlite(cfg_map, num_perf, cnx, perf_db_entry, cfg_entry,
   if cfg_entry.id in cfg_map:
     ins_cfg_id = cfg_map[cfg_entry.id]
   else:
-    cfg_dict = get_cfg_dict(cfg_entry, cfg_entry.input_t)
-
-    #override cfg layout with fdb key layout
-    if perf_db_entry.fdb_key:
-      fds, vals, _, _ = parse_pdb_key(perf_db_entry.fdb_key)
-      key_layout = vals[fds.index('out_layout')]
-      if cfg_dict['layout'] != key_layout:
-        raise ValueError("Out layout doesn't match fdb_key"\
-                         f" {cfg_dict['layout']} != {key_layout}")
+    cfg_dict = get_sqlite_cfg_dict(perf_db_entry.fdb_key)
 
     #filters cfg_dict by SQLITE_CONFIG_COLS, inserts cfg if missing
     ins_cfg_id = get_config_sqlite(cnx, cfg_dict)
@@ -458,6 +441,10 @@ def run_export_db(args: argparse.Namespace, logger: logging.Logger):
       args.num_cu = dbt.session.num_cu
     except ValueError as terr:
       logger.error(terr)
+
+  args.src_table = dbt.find_db_table
+  if args.golden_v is not None:
+    args.src_table = dbt.golden_table
 
   if args.find_db:
     result_file = export_fdb(dbt, args, logger)

--- a/tuna/miopen/utils/analyze_parse_db.py
+++ b/tuna/miopen/utils/analyze_parse_db.py
@@ -32,6 +32,7 @@ import sqlite3
 from typing import Any, List, Tuple
 from tuna.utils.logger import setup_logger
 from tuna.miopen.utils.metadata import SQLITE_CONFIG_COLS, ARCH_NUM_CU_LIST
+from tuna.miopen.utils.parsing import get_fds_from_cmd
 
 LOGGER = setup_logger('AnalyzeParseDB')
 
@@ -189,6 +190,22 @@ def parse_pdb_filename(fname: str) -> Tuple[str, int]:
     raise ValueError('Invalid perf db filename')
 
   return (arch, num_cu)
+
+
+def get_sqlite_cfg_dict(fdb_key: str) -> dict:
+  """get sqlite pdb config from fdb key"""
+  #replace direction with F to allow parsing as stored by sqlite pdb
+  basic_fwd = fdb_key[0:fdb_key.rfind('-') + 1] + 'F'
+  basic_fwd = basic_fwd + fdb_key[fdb_key.rfind('-') + 2:]
+  #add = for parsing function to treat like fdb
+  basic_fwd = basic_fwd + '='
+  direction = fdb_key[fdb_key.rfind('-') + 1]
+  cfg, data_type, _ = get_fds_from_cmd(basic_fwd)
+  cfg['direction'] = direction
+  cfg['layout'] = cfg['out_layout']
+  cfg['data_type'] = data_type
+  cfg['bias'] = 0
+  return cfg
 
 
 def mysql_to_sqlite_cfg(in_perf_cfg: dict) -> dict:

--- a/tuna/miopen/utils/parsing.py
+++ b/tuna/miopen/utils/parsing.py
@@ -58,9 +58,12 @@ def parse_pdb_key(key):
   if search(pattern_3d, key):
     vals, precision, direction = parse_3d(key, group_count)
     fds = FDS_3D
+    vals.append('3')
   else:
     vals, precision, direction = parse_2d(key, group_count)
     fds = FDS_2D
+    vals.append('2')
+  fds.append('spatial_dim')
 
   vals2 = []
   for val in vals:
@@ -92,7 +95,7 @@ def parse_2d(key, group_count):  #pylint: disable=too-many-locals
   direction = tmp[len(tmp) - 1]
   precision = tmp[len(tmp) - 2]
 
-  if direction == 'F':
+  if direction.startswith('F'):
     in_channels = tmp[0]
     in_h = tmp[1]
     in_w = tmp[2]
@@ -107,7 +110,7 @@ def parse_2d(key, group_count):  #pylint: disable=too-many-locals
   fil_h, fil_w = tmp[3].split('x')
   batchsize = tmp[7]
   pad_h, pad_w = tmp[8].split('x')
-  conv_stride_w, conv_stride_h = tmp[9].split('x')
+  conv_stride_h, conv_stride_w = tmp[9].split('x')
   dilation_h, dilation_w = tmp[10].split('x')
   # unused bias = tmp[11]
   # unused layout = tmp[12]
@@ -143,7 +146,7 @@ def parse_3d(key, group_count):  #pylint: disable=too-many-locals
   direction = tmp[len(tmp) - 1]
   precision = tmp[len(tmp) - 2]
 
-  if direction == 'F':
+  if direction.startswith('F'):
     in_channels = tmp[0]
     in_d = tmp[1]
     in_h = tmp[2]
@@ -160,7 +163,7 @@ def parse_3d(key, group_count):  #pylint: disable=too-many-locals
   fil_d, fil_h, fil_w = tmp[4].split('x')
   batchsize = tmp[9]
   pad_d, pad_h, pad_w = tmp[10].split('x')
-  conv_stride_d, conv_stride_w, conv_stride_h = tmp[11].split('x')
+  conv_stride_d, conv_stride_h, conv_stride_w = tmp[11].split('x')
   dilation_d, dilation_h, dilation_w = tmp[12].split('x')
   # unused bias = tmp[13]
 
@@ -209,7 +212,7 @@ def set_forward_dir(lst, fds_dict, output_h, output_w, precision):
   lst.append(str(int(output_w)))
   lst.append(str(fds_dict['batchsize']))
   lst.append(f"{fds_dict['pad_h']}x{fds_dict['pad_w']}")
-  lst.append(f"{fds_dict['conv_stride_w']}x{fds_dict['conv_stride_h']}")
+  lst.append(f"{fds_dict['conv_stride_h']}x{fds_dict['conv_stride_w']}")
   lst.append(f"{fds_dict['dilation_h']}x{fds_dict['dilation_w']}")
   lst.append('0')  # bias
   lst.append('NCHW')  # only supported format
@@ -230,7 +233,7 @@ def set_nonforward_dir(lst, fds_dict, output_h, output_w, precision, direction):
   lst.append(str(fds_dict['in_w']))
   lst.append(str(fds_dict['batchsize']))
   lst.append(f"{fds_dict['pad_h']}x{fds_dict['pad_w']}")
-  lst.append(f"{fds_dict['conv_stride_w']}x{fds_dict['conv_stride_h']}")
+  lst.append(f"{fds_dict['conv_stride_h']}x{fds_dict['conv_stride_w']}")
   lst.append(f"{fds_dict['dilation_h']}x{fds_dict['dilation_w']}")
   lst.append('0')  # bias
   lst.append('NCHW')  # only supported format
@@ -249,12 +252,12 @@ def get_pdb_key(fds_dict, precision, direction='F'):
   fil_w = int(fds_dict['fil_w'])
   pad_h = int(fds_dict['pad_h'])
   pad_w = int(fds_dict['pad_w'])
-  conv_stride_w = int(fds_dict['conv_stride_w'])
   conv_stride_h = int(fds_dict['conv_stride_h'])
+  conv_stride_w = int(fds_dict['conv_stride_w'])
 
   try:
-    output_h = ((in_h - fil_h + 2 * pad_h) / conv_stride_w) + 1
-    output_w = ((in_w - fil_w + 2 * pad_w) / conv_stride_h) + 1
+    output_h = ((in_h - fil_h + 2 * pad_h) / conv_stride_h) + 1
+    output_w = ((in_w - fil_w + 2 * pad_w) / conv_stride_w) + 1
   except ZeroDivisionError as zerr:
     LOGGER.error(zerr)
     raise ValueError('Zero Division Error caught') from zerr

--- a/tuna/miopen/utils/parsing.py
+++ b/tuna/miopen/utils/parsing.py
@@ -95,7 +95,7 @@ def parse_2d(key, group_count):  #pylint: disable=too-many-locals
   direction = tmp[len(tmp) - 1]
   precision = tmp[len(tmp) - 2]
 
-  if direction.startswith('F'):
+  if direction == 'F':
     in_channels = tmp[0]
     in_h = tmp[1]
     in_w = tmp[2]
@@ -146,7 +146,7 @@ def parse_3d(key, group_count):  #pylint: disable=too-many-locals
   direction = tmp[len(tmp) - 1]
   precision = tmp[len(tmp) - 2]
 
-  if direction.startswith('F'):
+  if direction == 'F':
     in_channels = tmp[0]
     in_d = tmp[1]
     in_h = tmp[2]


### PR DESCRIPTION
fdb key parsing: Correct ordering for stride dimensions, add spatial_dim.
kdb export: Code branch for combined skew db entries, storing entries for both skews when fdbs are separate. Remove device id from -mcpu kernel argument.
pdb export: Change method for creating config dict for sqlite to use fdb key.