### PR TITLE
Remove arch_full column from Machine and gather the same data in SessionRocMLIR where it's used

### DIFF
--- a/tuna/machine.py
+++ b/tuna/machine.py
@@ -70,6 +70,7 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
   password: str = Column(Text, nullable=False)
   avail_gpus: List[int] = Column(Text, nullable=False)
   arch: str = Column(Text, nullable=False)
+  arch_full: str = Column(Text, nullable=False, default=arch)
   num_cu: int = Column(INTEGER, nullable=False, server_default="64")
   sclk: int = Column(INTEGER)
   mclk: int = Column(INTEGER)
@@ -89,7 +90,7 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
     allowed_keys: Set = set([
         'id', 'hostname', 'user', 'password', 'port', 'ipmi_ip', 'ipmi_port',
         'ipmi_user', 'ipmi_password', 'ipmi_inaccessible', 'sclk', 'mclk',
-        'arch', 'num_cu', 'avail_gpus', 'local_machine'
+        'arch', 'arch_full', 'num_cu', 'avail_gpus', 'local_machine'
     ])
     self.__dict__.update(
         (key, None) for key in allowed_keys if key not in self.__dict__)
@@ -119,6 +120,7 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
 
       if self.gpus:
         self.arch = self.gpus[0]['arch']
+        self.arch_full = self.gpus[0]['arch_full']
         self.num_cu = self.gpus[0]['num_cu']
         self.avail_gpus = list(range(len(self.gpus)))
     else:
@@ -294,9 +296,15 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
     for i in alist:
       agent = agents[i]
       if agent['Device Type'] == 'GPU':
+        try:
+          arch_full = agent['ISA Info']['ISA 1']['Name']
+          arch_full = arch_full.replace('amdgcn-amd-amdhsa--', '')
+        except KeyError:
+          arch_full = agent['Name']
         details = {
             'rinfo': agent,
             'arch': agent['Name'],
+            'arch_full': arch_full,
             'num_cu': int(agent['Compute Unit'])
         }
         self.gpus.append(details)

--- a/tuna/machine.py
+++ b/tuna/machine.py
@@ -70,7 +70,6 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
   password: str = Column(Text, nullable=False)
   avail_gpus: List[int] = Column(Text, nullable=False)
   arch: str = Column(Text, nullable=False)
-  arch_full: str = Column(Text, nullable=False, default=arch)
   num_cu: int = Column(INTEGER, nullable=False, server_default="64")
   sclk: int = Column(INTEGER)
   mclk: int = Column(INTEGER)
@@ -90,7 +89,7 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
     allowed_keys: Set = set([
         'id', 'hostname', 'user', 'password', 'port', 'ipmi_ip', 'ipmi_port',
         'ipmi_user', 'ipmi_password', 'ipmi_inaccessible', 'sclk', 'mclk',
-        'arch', 'arch_full', 'num_cu', 'avail_gpus', 'local_machine'
+        'arch', 'num_cu', 'avail_gpus', 'local_machine'
     ])
     self.__dict__.update(
         (key, None) for key in allowed_keys if key not in self.__dict__)
@@ -120,7 +119,6 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
 
       if self.gpus:
         self.arch = self.gpus[0]['arch']
-        self.arch_full = self.gpus[0]['arch_full']
         self.num_cu = self.gpus[0]['num_cu']
         self.avail_gpus = list(range(len(self.gpus)))
     else:
@@ -296,15 +294,9 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
     for i in alist:
       agent = agents[i]
       if agent['Device Type'] == 'GPU':
-        try:
-          arch_full = agent['ISA Info']['ISA 1']['Name']
-          arch_full = arch_full.replace('amdgcn-amd-amdhsa--', '')
-        except KeyError:
-          arch_full = agent['Name']
         details = {
             'rinfo': agent,
             'arch': agent['Name'],
-            'arch_full': arch_full,
             'num_cu': int(agent['Compute Unit'])
         }
         self.gpus.append(details)

--- a/tuna/machine.py
+++ b/tuna/machine.py
@@ -70,7 +70,7 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
   password: str = Column(Text, nullable=False)
   avail_gpus: List[int] = Column(Text, nullable=False)
   arch: str = Column(Text, nullable=False)
-  arch_full: str = Column(Text, nullable=False, default=arch)
+  arch_full: str = arch
   num_cu: int = Column(INTEGER, nullable=False, server_default="64")
   sclk: int = Column(INTEGER)
   mclk: int = Column(INTEGER)

--- a/tuna/rocmlir/rocmlir_tables.py
+++ b/tuna/rocmlir/rocmlir_tables.py
@@ -93,15 +93,7 @@ class SessionRocMLIR(BASE, SessionMixin):
     if hasattr(args, 'arch_full') and args.arch_full:
       self.arch_full = args.arch_full
     else:
-      arch_full = worker.machine.arch
-      if worker.machine.gpus:
-        try:
-          gpu = worker.machine.gpus[0]['rinfo']
-          arch_full = gpu['ISA Info']['ISA 1']['Name']
-          arch_full = arch_full.replace('amdgcn-amd-amdhsa--', '')
-        except KeyError:
-          pass
-      self.arch_full = arch_full
+      self.arch_full = worker.machine.arch_full
 
     if hasattr(args, 'config_type') and args.config_type:
       self.config_type = args.config_type

--- a/tuna/rocmlir/rocmlir_tables.py
+++ b/tuna/rocmlir/rocmlir_tables.py
@@ -93,7 +93,15 @@ class SessionRocMLIR(BASE, SessionMixin):
     if hasattr(args, 'arch_full') and args.arch_full:
       self.arch_full = args.arch_full
     else:
-      self.arch_full = worker.machine.arch_full
+      arch_full = worker.machine.arch
+      if worker.machine.gpus:
+        try:
+          gpu = worker.machine.gpus[0]['rinfo']
+          arch_full = gpu['ISA Info']['ISA 1']['Name']
+          arch_full = arch_full.replace('amdgcn-amd-amdhsa--', '')
+        except KeyError:
+          pass
+      self.arch_full = arch_full
 
     if hasattr(args, 'config_type') and args.config_type:
       self.config_type = args.config_type

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -81,7 +81,7 @@ def getMachine() {
 def addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port) {
     runsql("TRUNCATE machine;")
 // TODO: this should come from different nodes
-    runsql("INSERT INTO machine(hostname, local_ip, local_port,  avail_gpus, user, password, port, arch, arch_full, num_cu, available, ipmi_inaccessible) VALUES(\'${machine_ip}\', \'${machine_local_ip}\', 22, \'0,1,2,3\', \'${username}\', \'${pwd}\', ${port}, \'${arch}\', \'${arch}\', ${num_cu}, TRUE, TRUE)" )
+    runsql("INSERT INTO machine(hostname, local_ip, local_port,  avail_gpus, user, password, port, arch, num_cu, available, ipmi_inaccessible) VALUES(\'${machine_ip}\', \'${machine_local_ip}\', 22, \'0,1,2,3\', \'${username}\', \'${pwd}\', ${port}, \'${arch}\', ${num_cu}, TRUE, TRUE)" )
 }
 
 


### PR DESCRIPTION
Since machine.gpus retains all the data that was parsed to set arch_full, it turned out to be easy to remove the arch_full field and do the same work in add_new_session.