### PR TITLE
Catching up on rocMLIR changes:  quick-tuning, attention op, backward data, small robustness improvements

### DIFF
--- a/tuna/machine.py
+++ b/tuna/machine.py
@@ -70,7 +70,7 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
   password: str = Column(Text, nullable=False)
   avail_gpus: List[int] = Column(Text, nullable=False)
   arch: str = Column(Text, nullable=False)
-  arch_full: str = arch
+  arch_full: str = ''
   num_cu: int = Column(INTEGER, nullable=False, server_default="64")
   sclk: int = Column(INTEGER)
   mclk: int = Column(INTEGER)

--- a/tuna/rocmlir/config_type.py
+++ b/tuna/rocmlir/config_type.py
@@ -27,4 +27,4 @@
 """Module that encapsulates different configuration types supported by Tuna"""
 from enum import Enum
 
-ConfigType = Enum('ConfigType', ['convolution', 'gemm'])
+ConfigType = Enum('ConfigType', ['convolution', 'gemm', 'attention'])

--- a/tuna/rocmlir/rocmlir_lib.py
+++ b/tuna/rocmlir/rocmlir_lib.py
@@ -81,6 +81,7 @@ class RocMLIR(MITunaInterface):
         help='Which space of tuning configs should be used while tuning')
 
     group: argparse._MutuallyExclusiveGroup = parser.add_mutually_exclusive_group(
+      required=True
     )
     group.add_argument('--add_tables',
                        dest='add_tables',
@@ -89,7 +90,6 @@ class RocMLIR(MITunaInterface):
 
     # pylint: disable=duplicate-code
     group.add_argument(
-        '-e',
         '--execute',
         dest='execute',
         action='store_true',
@@ -185,8 +185,8 @@ class RocMLIR(MITunaInterface):
         SessionRocMLIR().add_new_session(self.args, worker)
       return None
 
-    assert self.args.execute, \
-      "one of --add_tables, --init_session, or --execute must be present"
+    # Must be --execute, because the mutually-exclusive-group argument is
+    # required, and we just checked for --add_tables and --init_session.
     res = self.compose_worker_list(machines)
     return res
 

--- a/tuna/rocmlir/rocmlir_lib.py
+++ b/tuna/rocmlir/rocmlir_lib.py
@@ -73,6 +73,12 @@ class RocMLIR(MITunaInterface):
                         help='How many workers per GPU',
                         default=1.0,
                         type=float)
+    parser.add_argument(
+        '--tuning_space',
+        dest='tuning_space',
+        default='exhaustive',
+        choices=['quick', 'full', 'exhaustive'],
+        help='Which space of tuning configs should be used while tuning')
 
     group: argparse._MutuallyExclusiveGroup = parser.add_mutually_exclusive_group(
     )
@@ -153,8 +159,10 @@ class RocMLIR(MITunaInterface):
     # pylint: disable=duplicate-code
     """Generates the library specific schema to the connected SQL server."""
     ret_t: bool = create_tables(get_tables())
-    recreate_triggers(['conv_timestamp_trigger', 'gemm_timestamp_trigger'],
-                      get_timestamp_trigger())
+    recreate_triggers([
+        'conv_timestamp_trigger', 'gemm_timestamp_trigger',
+        'attention_timestamp_trigger'
+    ], get_timestamp_trigger())
     self.logger.info('DB creation successful: %s', ret_t)
     return True
 
@@ -177,6 +185,8 @@ class RocMLIR(MITunaInterface):
         SessionRocMLIR().add_new_session(self.args, worker)
       return None
 
+    assert self.args.execute, \
+      "one of --add_tables, --init_session, or --execute must be present"
     res = self.compose_worker_list(machines)
     return res
 

--- a/tuna/rocmlir/rocmlir_lib.py
+++ b/tuna/rocmlir/rocmlir_lib.py
@@ -81,8 +81,7 @@ class RocMLIR(MITunaInterface):
         help='Which space of tuning configs should be used while tuning')
 
     group: argparse._MutuallyExclusiveGroup = parser.add_mutually_exclusive_group(
-      required=True
-    )
+        required=True)
     group.add_argument('--add_tables',
                        dest='add_tables',
                        action='store_true',

--- a/tuna/rocmlir/rocmlir_tables.py
+++ b/tuna/rocmlir/rocmlir_tables.py
@@ -286,14 +286,14 @@ class ConvolutionConfig(BASE):
 
   ## Adapted from perfRunner.getConvConfigurations.
 
-  DIRECTIONS = ['-F 1', '-F 2', '-F 4']
-  DATA_TYPES = ['conv', 'convfp16', 'convint8']
-  LAYOUTS = ['NHWC', 'NCHW']
-
   def get_configurations(self, filename):
     """Read conv-configs from filename and expand into all combinations of
          direction, type, and layout.
       """
+
+    DIRECTIONS = ['-F 1', '-F 2', '-F 4']
+    DATA_TYPES = ['conv', 'convfp16', 'convint8']
+    LAYOUTS = ['NHWC', 'NCHW']
 
     configs = []
     with open(filename, 'r', encoding='utf8') as config_file:
@@ -301,8 +301,7 @@ class ConvolutionConfig(BASE):
 
       # All combinations of conv direction, type and layouts
       for direction, datatype, layout, line in \
-              itertools.product(self.DIRECTIONS, self.DATA_TYPES, self.LAYOUTS,
-                                lines):
+              itertools.product(DIRECTIONS, DATA_TYPES, LAYOUTS, lines):
         line = line.strip()
 
         # Skip empty lines
@@ -314,7 +313,7 @@ class ConvolutionConfig(BASE):
 
         # Skip datatype if already in
         datatype = f"{datatype} "
-        # check for the presense of a positional arg
+        # check for the presence of a positional arg
         if line[0][0] != "-":
           datatype = ""
 
@@ -513,13 +512,13 @@ class GEMMConfig(BASE):
 
   ## Adapted from perfRunner.getGemmConfigurations.
 
-  DATA_TYPES = ['f32', 'f16', 'i8']
-
   def get_configurations(self, filename):
     #pylint: disable=invalid-name
     """Read gemm-configs from filename and expand into all combinations of
          type and transpose.
       """
+
+    DATA_TYPES = ['f32', 'f16', 'i8']
 
     configs = []
     with open(filename, 'r', encoding='utf8') as config_file:
@@ -527,7 +526,7 @@ class GEMMConfig(BASE):
 
       # All combinations of types and transposition (A and B)
       for datatype, transA, transB, line in \
-              itertools.product(self.DATA_TYPES, ['false', 'true'],
+              itertools.product(DATA_TYPES, ['false', 'true'],
                                 ['false', 'true'], lines):
         line = line.strip()
 
@@ -685,8 +684,6 @@ class AttentionConfig(BASE):
 
   ## Adapted from perfRunner.getGemmConfigurations.
 
-  DATA_TYPES = ['f32', 'f16']
-
   def get_configurations(self, filename):
     #pylint: disable=invalid-name
     #pylint: disable=too-many-locals
@@ -694,13 +691,15 @@ class AttentionConfig(BASE):
        type and transpose.
     """
 
+    DATA_TYPES = ['f32', 'f16']
+
     configs = []
     with open(filename, 'r', encoding='utf8') as config_file:
       lines = config_file.readlines()
 
       # All combinations of types and transposition (A and B)
       for datatype, transQ, transK, transV, transO, withAttnScale, line in \
-              itertools.product(self.DATA_TYPES, ['false', 'true'],
+              itertools.product(DATA_TYPES, ['false', 'true'],
                                 ['false', 'true'], ['false', 'true'],
                                 ['false', 'true'], ['false', 'true'], lines):
         line = line.strip()

--- a/tuna/rocmlir/rocmlir_tables.py
+++ b/tuna/rocmlir/rocmlir_tables.py
@@ -319,13 +319,15 @@ class ConvolutionConfig(BASE):
         if datatype == 'convint8' and direction != '-F 1':
           continue
 
-        # Skip datatype if already in
-        one_config = f"{datatype} "
-        # check for the presence of a positional arg
-        if line[0][0] != "-":
-          one_config = ""
+        # Add options if they aren't already supplied.
+        # We need trailing spaces here to account for the string concat.
 
-        one_config += make_option_if_not_in_line("-F", direction, line)
+        # For datatype, check for the presence of a positional arg.
+        if line[0][0] == "-":
+          one_config = f"{datatype} "
+
+        if "-F" not in line:
+          one_config += f"{direction} "  # -F included in direction.
         one_config += make_option_if_not_in_line("-f", layout, line)
         one_config += make_option_if_not_in_line("-I", layout, line)
         one_config += make_option_if_not_in_line("-O", layout, line)
@@ -548,18 +550,18 @@ class GEMMConfig(BASE):
           outDataTypeString = f"-out_datatype {datatype} "
 
         # Strip to avoid spurious spaces
-        oneConfig = f"{dataTypeString}{outDataTypeString}\
-                      {transAString}{transBString}{line}".strip()
-        if oneConfig not in configs:
-          configs.append(oneConfig)
+        one_config = f"{dataTypeString}{outDataTypeString}\
+                       {transAString}{transBString}{line}".strip()
+        if one_config not in configs:
+          configs.append(one_config)
 
         # Special case to get both i8_i8 and i8_i32, w/o --data-type or output-type-map.
         if "-out_datatype" not in line and datatype == 'i8':
           outDataTypeString = "-out_datatype i32 "
-          oneConfig = f"{dataTypeString}{outDataTypeString}\
-                        {transAString}{transBString}{line}".strip()
-          if oneConfig not in configs:
-            configs.append(oneConfig)
+          one_config = f"{dataTypeString}{outDataTypeString}\
+                         {transAString}{transBString}{line}".strip()
+          if one_config not in configs:
+            configs.append(one_config)
 
     return configs
 
@@ -696,20 +698,20 @@ class AttentionConfig(BASE):
         if len(line) == 0 or line[0] == '#':
           continue
 
-        oneConfig = ""
-        oneConfig += make_option_if_not_in_line("-t", datatype, line)
-        oneConfig += make_option_if_not_in_line("-transQ", transQ, line)
-        oneConfig += make_option_if_not_in_line("-transK", transK, line)
-        oneConfig += make_option_if_not_in_line("-transV", transV, line)
-        oneConfig += make_option_if_not_in_line("-transO", transO, line)
-        oneConfig += make_option_if_not_in_line("-with-attn-scale",
-                                                withAttnScale, line)
+        one_config = ""
+        one_config += make_option_if_not_in_line("-t", datatype, line)
+        one_config += make_option_if_not_in_line("-transQ", transQ, line)
+        one_config += make_option_if_not_in_line("-transK", transK, line)
+        one_config += make_option_if_not_in_line("-transV", transV, line)
+        one_config += make_option_if_not_in_line("-transO", transO, line)
+        one_config += make_option_if_not_in_line("-with-attn-scale",
+                                                 withAttnScale, line)
 
         # Strip to avoid spurious spaces
-        oneConfig += line
-        oneConfig = oneConfig.strip()
-        if oneConfig not in configs:
-          configs.append(oneConfig)
+        one_config += line
+        one_config = one_config.strip()
+        if one_config not in configs:
+          configs.append(one_config)
 
     return configs
 

--- a/tuna/rocmlir/rocmlir_tables.py
+++ b/tuna/rocmlir/rocmlir_tables.py
@@ -46,6 +46,7 @@ from tuna.db.session_mixin import SessionMixin
 from tuna.utils.logger import setup_logger
 from tuna.tables_interface import DBTablesInterface
 from tuna.rocmlir.config_type import ConfigType
+from tuna.rocmlir.tuning_space import TuningSpace
 
 #pylint: disable=too-few-public-methods
 
@@ -59,6 +60,7 @@ class SessionRocMLIR(BASE, SessionMixin):
   arch_full = Column(String(length=64), nullable=False)
   # For convenience of commands.
   config_type = Column(Enum(ConfigType))
+  tuning_space = Column(Enum(TuningSpace))
 
   __tablename__ = "session_rocmlir"
   __table_args__ = (UniqueConstraint("arch",
@@ -67,6 +69,7 @@ class SessionRocMLIR(BASE, SessionMixin):
                                      "mlir_v",
                                      "reason",
                                      "config_type",
+                                     "tuning_space",
                                      name="uq_idx"),)
 
   def get_query(self, sess, sess_obj, entry):
@@ -77,7 +80,8 @@ class SessionRocMLIR(BASE, SessionMixin):
         .filter(sess_obj.rocm_v == entry.rocm_v)\
         .filter(sess_obj.mlir_v == entry.mlir_v)\
         .filter(sess_obj.reason == entry.reason)\
-        .filter(sess_obj.config_type == entry.config_type)
+        .filter(sess_obj.config_type == entry.config_type)\
+        .filter(sess_obj.tuning_space == entry.tuning_space)
 
     return query
 
@@ -97,6 +101,10 @@ class SessionRocMLIR(BASE, SessionMixin):
 
     if hasattr(args, 'config_type') and args.config_type:
       self.config_type = args.config_type
+
+    self.tuning_space = "exhaustive"
+    if hasattr(args, 'tuning_space') and args.tuning_space:
+      self.tuning_space = args.tuning_space
 
     return self.insert_session()
 
@@ -278,9 +286,7 @@ class ConvolutionConfig(BASE):
 
   ## Adapted from perfRunner.getConvConfigurations.
 
-  #DIRECTIONS = ['-F 1', '-F 2', '-F 4']
-  # temporarily disable backward-data until rocmlir-tuning-driver can handle multi-kernel code
-  DIRECTIONS = ['-F 1', '-F 4']
+  DIRECTIONS = ['-F 1', '-F 2', '-F 4']
   DATA_TYPES = ['conv', 'convfp16', 'convint8']
   LAYOUTS = ['NHWC', 'NCHW']
 
@@ -579,6 +585,183 @@ class GEMMResults(BASE, ResultsMixin):  # pylint: disable=too-many-instance-attr
                   index=True)
 
 
+class AttentionJob(BASE, JobMixin):
+  """Represents attention job table"""
+  __tablename__ = "rocmlir_attention_job"
+  __table_args__ = (UniqueConstraint('config', 'session', name="uq_idx"),)
+
+  config = Column(Integer,
+                  ForeignKey("rocmlir_attention_config.id"),
+                  nullable=False,
+                  index=True)
+
+
+class AttentionConfig(BASE):
+  """Represents Attention config table"""
+  __tablename__ = "rocmlir_attention_config"
+
+  data_type = Column(String(length=60), nullable=False, server_default="")
+  group_size = Column(Integer, nullable=False, server_default="0")
+  seq_len = Column(Integer, nullable=False, server_default="0")
+  head_dim = Column(Integer, nullable=False, server_default="0")
+  with_attn_scale = Column(Boolean, nullable=False, server_default="0")
+  transpose_Q = Column(Boolean, nullable=False, server_default="0")
+  transpose_K = Column(Boolean, nullable=False, server_default="0")
+  transpose_V = Column(Boolean, nullable=False, server_default="0")
+  transpose_O = Column(Boolean, nullable=False, server_default="0")
+  kernel_repeats = Column(Integer, nullable=False, server_default="0")
+
+  def __repr__(self) -> str:
+    return f"AttentionConfig {self.to_dict()}"
+
+  # This dict maps field names, which are also the long option names, to
+  # the short forms used in the configs.  Necessary to turn a
+  # AttentionConfig back into a string that we can pass to the runner.
+  options = {
+      'data_type': '-t',
+      'transpose_Q': '-transQ',
+      'transpose_K': '-transK',
+      'transpose_V': '-transV',
+      'transpose_O': '-transO',
+      'group_size': '-g',
+      'seq_len': '-seq_len',
+      'head_dim': '-head_dim',
+      'with_attn_scale': '-with-attn-scale',
+      # Count on tuneMLIRKernels to set config.MLIR_N_REPEATS to 1.
+      #    'kernel_repeats': '--kernel-repeats',
+      'kernel_repeats': None,
+      'id': None,
+      'valid': None
+  }
+
+  def config_string(self):
+    """Return config as a flag/value string suitable for tuningRunner.py."""
+    string = ""
+    #     for field, value in self.to_dict().items():
+    #       flag = self.options[field]
+    #       if flag:
+    #         string += f"{flag} {value} "
+    # In options order for canonicalisation, kind of.
+    for field, flag in self.options.items():
+      value = getattr(self, field, None)
+      if value is not None and flag is not None:
+        string += f"{flag} {value} "
+    return string.strip()
+
+  def parse_line(self, line):
+    """Parse a command-line-style attention config into a AttentionConfig object."""
+
+    print(f"Parsing line {line}")
+
+    # Convert the line ("-n 256 -c 1024 -H 14 ...") to dict of flag and value.
+    i = iter(line.split())
+    options = dict(zip(i, i))
+    #  print(f"options = {options}")
+
+    # Mapping of flag to field name.
+    # -transA false -transB false -g 64 -m 1024 -n 384 -k 1024
+    fields = {
+        '-transQ': 'transpose_Q',
+        '-transK': 'transpose_K',
+        '-transV': 'transpose_V',
+        '-transO': 'transpose_O',
+        '-g': 'group_size',
+        '-seq_len': 'seq_len',
+        '-head_dim': 'head_dim',
+        '-with-attn-scale': 'with_attn_scale',
+        '-t': 'data_type'
+    }
+    # kernel-repeats has no flag, but perfRunner.py uses 5.
+
+    self.kernel_repeats = 1
+    for flag, value in options.items():
+      if value == "true":
+        value = 1
+      if value == "false":
+        value = 0
+      field = fields[flag]
+      if field:
+        setattr(self, field, value)
+
+  ## Adapted from perfRunner.getGemmConfigurations.
+
+  DATA_TYPES = ['f32', 'f16']
+
+  def get_configurations(self, filename):
+    #pylint: disable=invalid-name
+    #pylint: disable=too-many-locals
+    """Read attention-configs from filename and expand into all combinations of
+       type and transpose.
+    """
+
+    configs = []
+    with open(filename, 'r', encoding='utf8') as config_file:
+      lines = config_file.readlines()
+
+      # All combinations of types and transposition (A and B)
+      for datatype, transQ, transK, transV, transO, withAttnScale, line in \
+              itertools.product(self.DATA_TYPES, ['false', 'true'],
+                                ['false', 'true'], ['false', 'true'],
+                                ['false', 'true'], ['false', 'true'], lines):
+        line = line.strip()
+
+        # Skip empty lines
+        if len(line) == 0 or line[0] == '#':
+          continue
+
+        # We need trailing spaces here to account for the concat below
+        # Skip type if already in
+        dataTypeString = ""
+        if "-t " not in line:
+          dataTypeString = f"-t {datatype} "
+
+        # Skip transQ if already in
+        transQString = ""
+        if "-transQ " not in line:
+          transQString = f"-transQ {transQ} "
+
+        # Skip transK if already in
+        transKString = ""
+        if "-transK " not in line:
+          transKString = f"-transK {transK} "
+
+        # Skip transV if already in
+        transVString = ""
+        if "-transV " not in line:
+          transVString = f"-transV {transV} "
+
+        # Skip transO if already in
+        transOString = ""
+        if "-transO " not in line:
+          transOString = f"-transO {transO} "
+
+        # Skip withAttnScale if already in
+        withAttnScaleString = ""
+        if "-with-attn-scale " not in line:
+          withAttnScaleString = f"-with-attn-scale {withAttnScale} "
+
+        # Strip to avoid spurious spaces
+        oneConfig = f"{dataTypeString}{transQString}{transKString}\
+                      {transVString}{transOString}{withAttnScaleString}{line}"\
+                      .strip()
+        if oneConfig not in configs:
+          configs.append(oneConfig)
+
+    return configs
+
+
+class AttentionResults(BASE, ResultsMixin):  # pylint: disable=too-many-instance-attributes
+  """Collects the results of Attention tuning."""
+
+  __tablename__ = "rocmlir_attention_results"
+  __table_args__ = (UniqueConstraint("config", "session", name="uq_idx"),)
+
+  config = Column(Integer,
+                  ForeignKey("rocmlir_attention_config.id"),
+                  nullable=False,
+                  index=True)
+
+
 #pylint: disable=too-few-public-methods
 class RocMLIRDBTables(DBTablesInterface):
   """Represents db tables for rocMLIR lib"""
@@ -608,6 +791,10 @@ class RocMLIRDBTables(DBTablesInterface):
       self.job_table = GEMMJob
       self.config_table = GEMMConfig
       self.results = GEMMResults
+    elif self.config_type == ConfigType.attention:
+      self.job_table = AttentionJob
+      self.config_table = AttentionConfig
+      self.results = AttentionResults
     else:
       raise ValueError(f"Config type {self.config_type} not yet supported.")
 
@@ -632,6 +819,9 @@ def get_tables() -> List[BASE]:
     append_if_not_exists(GEMMConfig())
     append_if_not_exists(GEMMJob())
     append_if_not_exists(GEMMResults())
+    append_if_not_exists(AttentionConfig())
+    append_if_not_exists(AttentionJob())
+    append_if_not_exists(AttentionResults())
 
   return tables
 

--- a/tuna/rocmlir/rocmlir_worker.py
+++ b/tuna/rocmlir/rocmlir_worker.py
@@ -155,7 +155,7 @@ class RocMLIRWorker(WorkerInterface):
     # Not sure what to expect beyond OSError.
     except Exception as exc:
       self.logger.error('Exception occurred while running job %s:  %s',
-                        self.job.id, traceback.format_exc(exc))
+                        self.job.id, traceback.format_exc())
       self.set_job_state('error', result=str(exc).replace("'", r"\'"))
 
     return True

--- a/tuna/rocmlir/rocmlir_worker.py
+++ b/tuna/rocmlir/rocmlir_worker.py
@@ -32,6 +32,7 @@ from time import sleep
 import random
 import functools
 import logging
+import traceback
 from tenacity import Retrying, stop_after_attempt, before_sleep_log, wait_random
 
 from sqlalchemy.inspection import inspect
@@ -75,6 +76,11 @@ class RocMLIRWorker(WorkerInterface):
     print(f"arch = '{arch}', num_cu = '{num_cu}', config = '{config}', \
           perf_config = '{perf_config}', tflops = {tflops}",
           file=sys.stderr)
+
+    # Sanity checks.
+    if not perf_config or perf_config == 'None' or tflops == '-inf':
+      self.logger.warning('Bad data for job_id=%s, skipping', self.job.id)
+      return True  # To avoid an update retry.
 
     obj.valid = 1
     obj.session = self.dbt.session.id
@@ -141,18 +147,15 @@ class RocMLIRWorker(WorkerInterface):
               self.logger.info(msg)
               self.set_job_state('error', result=msg)
             else:
-              with open(self.output_filename(), 'r',
-                        encoding='utf8') as results:
-                # https://stackoverflow.com/questions/49902843/avoid-parameter-binding-when-executing-query-with-sqlalchemy
-                string = results.read().replace(':', r'\:')
-                self.set_job_state('completed', result=string)
-                self.process_result(string)
-              os.remove(self.output_filename())
+              # https://stackoverflow.com/questions/49902843/avoid-parameter-binding-when-executing-query-with-sqlalchemy
+              string = cmd_output.replace(':', r'\:')
+              self.set_job_state('completed', result=string)
+              self.process_result(string)
     # pylint: disable=broad-exception-caught
     # Not sure what to expect beyond OSError.
     except Exception as exc:
-      self.logger.warning('Exception occurred while running job %s:  %s',
-                          self.job.id, exc)
+      self.logger.error('Exception occurred while running job %s:  %s',
+                        self.job.id, traceback.format_exc(exc))
       self.set_job_state('error', result=str(exc).replace("'", r"\'"))
 
     return True
@@ -170,8 +173,12 @@ class RocMLIRWorker(WorkerInterface):
       special_args = "--operation conv"
     elif self.dbt.config_type == ConfigType.gemm:
       special_args = "--operation gemm"
+    elif self.dbt.config_type == ConfigType.attention:
+      special_args = "--operation attention --verify-mode none"
     else:
       raise ValueError(f"Config type {self.dbt.config_type} not yet supported.")
+    if self.dbt.session.tuning_space:
+      special_args += f" --tuning-space={self.dbt.session.tuning_space.name}"
 
     if not os.path.exists("./bin/tuningRunner.py"):
       raise FileNotFoundError("tuningRunner.py not found;"
@@ -179,8 +186,8 @@ class RocMLIRWorker(WorkerInterface):
 
     cmd = env_str + f" python3 ./bin/tuningRunner.py -q {special_args} \
                      --config='{config_string}' --mlir-build-dir `pwd` \
-                     --output={self.output_filename()} --tflops \
-                     --rocmlir_gen_flags='--device={self.gpu_id}'"
+                     --output=- --tflops \
+                     --rocmlir_gen_flags='--device={self.gpu_id}' 2>/dev/null"
 
     retcode, out = super().run_command(cmd)
 

--- a/tuna/rocmlir/tuning_space.py
+++ b/tuna/rocmlir/tuning_space.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 ###############################################################################
 #
 # MIT License
@@ -23,22 +24,7 @@
 # SOFTWARE.
 #
 ###############################################################################
-"""Database triggers for timestamps."""
+"""Module that encapsulates different tuning spaces used by tuning driver."""
+from enum import Enum
 
-
-def get_timestamp_trigger():
-  """setting up for job table triggers"""
-  trigger_template = """CREATE trigger {op}_timestamp_trigger before UPDATE on rocmlir_{op}_job
-  for each row
-  begin
-   if NEW.state='running' then set NEW.compile_start=now();
-   elseif NEW.state='completed' then set NEW.compile_end=now();
-   elseif NEW.state='error' then set NEW.compile_end=now();
-   end if;
-  end;"""
-
-  return [
-      trigger_template.format(op='conv'),
-      trigger_template.format(op='gemm'),
-      trigger_template.format(op='attention')
-  ]
+TuningSpace = Enum('TuningSpace', ["quick", "full", "exhaustive"])


### PR DESCRIPTION
Tuning-space support, enable backward-data tuning.
Tuning space as an Enum.
Improving exception reporting.
Use stdout instead of a results file for tuningRunner.py.
Support for attention op.
Bail without updating database if tuning data is clearly bogus, to avoid database barfs.
Initialise arch_full to empty string;  __init__ will default it to arch if needed.