### PR TITLE
Celery: queue purge on CTRL+C

### DIFF
--- a/tuna/celery_app/celery_app.py
+++ b/tuna/celery_app/celery_app.py
@@ -26,6 +26,7 @@
 ###############################################################################
 """Module to define celery app"""
 import os
+from subprocess import Popen, PIPE
 from celery import Celery
 from celery.utils.log import get_task_logger
 
@@ -51,6 +52,22 @@ def stop_active_workers():
   """Shutdown active workers"""
   if app.control.inspect().active() is not None:
     app.control.shutdown()
+
+  return True
+
+
+def purge_queue(q_names):
+  """Purge jobs in queue"""
+  for q_name in q_names:
+    try:
+      cmd = f"celery -A tuna.celery_app.celery_app purge -Q {q_name}"
+      process = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+      inputdata = "y"
+      stdoutdata, stderrdata = process.communicate(input=inputdata)
+      process.join()
+    except Exception as ex:
+      LOGGER.info()
+      return False
 
   return True
 

--- a/tuna/celery_app/celery_app.py
+++ b/tuna/celery_app/celery_app.py
@@ -26,7 +26,7 @@
 ###############################################################################
 """Module to define celery app"""
 import os
-from subprocess import Popen, PIPE
+import subprocess
 from celery import Celery
 from celery.utils.log import get_task_logger
 
@@ -56,17 +56,16 @@ def stop_active_workers():
   return True
 
 
-def purge_queue(q_names):
+def purge_queue(q_names, logger):
   """Purge jobs in queue"""
   for q_name in q_names:
     try:
-      cmd = f"celery -A tuna.celery_app.celery_app purge -Q {q_name}"
-      process = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-      inputdata = "y"
-      stdoutdata, stderrdata = process.communicate(input=inputdata)
-      process.join()
+      logger.info('Purging Q %s', q_name)
+      cmd = f"celery -A tuna.celery_app.celery_app purge -f -Q {q_name}".split(
+          ' ')
+      _ = subprocess.Popen(cmd)
     except Exception as ex:
-      LOGGER.info()
+      logger.info(ex)
       return False
 
   return True

--- a/tuna/miopen/celery_tuning/tuning.py
+++ b/tuna/miopen/celery_tuning/tuning.py
@@ -312,7 +312,7 @@ def tune(library, job_batch_size=1000):
 
   results_gather(res_set, worker_type)
   end = time.time()
-  LOGGER.info("Took {:0>8}".format(str(timedelta(seconds=(end - start)))))
+  LOGGER.info("Took {:0>8}".format(str(timedelta(seconds=end - start))))  #pylint: disable=consider-using-f-string
 
   return True
 

--- a/tuna/miopen/celery_tuning/tuning.py
+++ b/tuna/miopen/celery_tuning/tuning.py
@@ -307,6 +307,7 @@ def tune(library, job_batch_size=1000):
       except KeyboardInterrupt:
         LOGGER.error('Keyboard interrupt caught, draining results queue')
         session.rollback()
+        stop_active_workers()
         purge_queue([q_name], LOGGER)
         results_gather(res_set, worker_type)
 

--- a/tuna/miopen/celery_tuning/tuning.py
+++ b/tuna/miopen/celery_tuning/tuning.py
@@ -298,8 +298,6 @@ def tune(library, job_batch_size=1000):
 
             #calling celery task, enqueuing to celery queue
             res_set.add(hardware_pick.apply_async((context,), queue=q_name))
-            purge_queue(q_name)
-            exit()
 
         if not job_list:
           if not res_set:
@@ -309,7 +307,7 @@ def tune(library, job_batch_size=1000):
       except KeyboardInterrupt:
         LOGGER.error('Keyboard interrupt caught, draining results queue')
         session.rollback()
-        purge_queue(q_name)
+        purge_queue([q_name], LOGGER)
         results_gather(res_set, worker_type)
 
   results_gather(res_set, worker_type)


### PR DESCRIPTION
adding CTRL+C handler for purging tasks that have been enqueued. Celery does a warm shutdown on the workers but the tasks left in redis do not get purged.