### PR TITLE
GPU mismatch fixed in Eval

### DIFF
--- a/tuna/miopen/worker/fin_eval.py
+++ b/tuna/miopen/worker/fin_eval.py
@@ -297,6 +297,22 @@ class FinEvaluator(FinClass):
         return False
     return True
 
+  def check_env(self) -> bool:
+    """Interface function to check the miopen env version vs presumed miopen version"""
+    if super().check_env():
+      if self.dbt.session.arch != self.machine.arch:
+        raise ValueError(
+            f'session arch {self.dbt.session.arch} does not match machine arch\
+            {self.machine.arch}')
+      if self.dbt.session.num_cu != self.machine.num_cu:
+        raise ValueError(
+            f'session num_cu {self.dbt.session.num_cu} does not match machine num_cu\
+            {self.machine.num_cu}')
+    else:
+      return False
+
+    return True
+
   def step(self):
     """Function that defined the evaluator specific functionality which implies picking up jobs
     to benchmark and updating DB with evaluator specific state"""

--- a/tuna/miopen/worker/fin_eval.py
+++ b/tuna/miopen/worker/fin_eval.py
@@ -302,7 +302,10 @@ class FinEvaluator(FinClass):
     if super().check_env():
       if self.dbt.session.arch != self.machine.arch or \
               self.dbt.session.num_cu != self.machine.num_cu:
-        self.logger.error('Session arch/num_cu does not match env arch/num_cu')
+        self.logger.error(
+            'Session arch/num_cu (%s/%s) does not match env arch/num_cu (%s/%s)',
+            self.dbt.session.arch, self.dbt.session.num_cu, self.machine.arch,
+            self.machine.num_cu)
         return False
     else:
       return False

--- a/tuna/miopen/worker/fin_eval.py
+++ b/tuna/miopen/worker/fin_eval.py
@@ -298,7 +298,7 @@ class FinEvaluator(FinClass):
     return True
 
   def check_env(self) -> bool:
-    """Interface function to check the miopen env version vs presumed miopen version"""
+    """Check the GPU on the machine matches the GPU specified in session table"""
     if super().check_env():
       if self.dbt.session.arch != self.machine.arch:
         raise ValueError(

--- a/tuna/miopen/worker/fin_eval.py
+++ b/tuna/miopen/worker/fin_eval.py
@@ -300,14 +300,10 @@ class FinEvaluator(FinClass):
   def check_env(self) -> bool:
     """Check the GPU on the machine matches the GPU specified in session table"""
     if super().check_env():
-      if self.dbt.session.arch != self.machine.arch:
-        raise ValueError(
-            f'session arch {self.dbt.session.arch} does not match machine arch\
-            {self.machine.arch}')
-      if self.dbt.session.num_cu != self.machine.num_cu:
-        raise ValueError(
-            f'session num_cu {self.dbt.session.num_cu} does not match machine num_cu\
-            {self.machine.num_cu}')
+      if self.dbt.session.arch != self.machine.arch or \
+              self.dbt.session.num_cu != self.machine.num_cu:
+        self.logger.error('Session arch/num_cu does not match env arch/num_cu')
+        return False
     else:
       return False
 


### PR DESCRIPTION
MITuna allows for evaluation to be run even if the underlying GPU doesn't match the GPU configured for the tuning run. This PR prohibts this behaviour