### PR TITLE
RabbitMQ connection heartbeat

### DIFF
--- a/tuna/celery_app/celery_app.py
+++ b/tuna/celery_app/celery_app.py
@@ -87,6 +87,7 @@ app = Celery(
     f"amqp://{TUNA_CELERY_BROKER_USER}:{TUNA_CELERY_BROKER_PWD}@{TUNA_CELERY_BROKER_HOST}:{TUNA_CELERY_BROKER_PORT}/",
     result_backend=
     f"redis://{TUNA_CELERY_BACKEND_HOST}:{TUNA_CELERY_BACKEND_PORT}/15",
+    broker_transport_options={"heartbeat": 60},
     include=[
         'tuna.miopen.celery_tuning.celery_tasks',
         'tuna.example.celery_tuning.celery_tasks'


### PR DESCRIPTION
rabbitMQ fails to close stale connections by default and we run out of sockets (available connection).
Added heartbeat check at 60sec to close unresponsive connections and free up space.