### PR TITLE
libraries.py: fix typo

### DIFF
--- a/tuna/libraries.py
+++ b/tuna/libraries.py
@@ -24,7 +24,7 @@
 # SOFTWARE.
 #
 ###############################################################################
-"""Module that encapsulates different liraries supported by Tuna"""
+"""Module that encapsulates different libraries supported by Tuna"""
 from enum import Enum
 
 


### PR DESCRIPTION
While researching trace from go_fish.py to tuningRunner call noticed this typo in comment (typo and it's fix don't affect anything).