### PR TITLE
Collect comprehensive tuning results

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+relative_files = True
 source = ./tuna
 omit = 
       /usr/local/lib* 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,11 +69,27 @@ pipeline {
             }
             }
         }
-        stage("pytest"){
-        agent{  label "gfx90a" }
+        stage("pytest1"){
+        agent { label utils.rocmnode("tunatest") }
         steps{
             script{
             utils.pytestSuite1()
+            }
+            }
+        }
+        stage("pytest2"){
+        agent { label utils.rocmnode("tunatest") }
+        steps{
+            script{
+            utils.pytestSuite2()
+            }
+            }
+        }
+        stage("pytest3"){
+        agent{  label "gfx90a" }
+        steps{
+            script{
+            utils.pytestSuite3()
             }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,27 +69,11 @@ pipeline {
             }
             }
         }
-        stage("pytest1"){
-        agent{  label utils.rocmnode("tunatest") }
+        stage("pytest"){
+        agent{  label "gfx90a" }
         steps{
             script{
             utils.pytestSuite1()
-            }
-            }
-        }
-        stage("pytest2"){
-        agent{ label utils.rocmnode("tunatest") }
-        steps{
-            script{
-            utils.pytestSuite2()
-            }
-            }
-        }
-        stage("pytest3"){
-            agent{  label "gfx90a" }
-            steps {
-            script {
-            utils.pytestSuite3()
             }
             }
         }

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -177,12 +177,14 @@ def eval_step(machine, miopen, fin_step, num_jobs):
       miopen.process_eval_results(session, fin_json, context)
 
     valid_fin_err = session.query(miopen.dbt.job_table).filter(miopen.dbt.job_table.session==miopen.args.session_id)\
+                                         .filter(miopen.dbt.job_table.reason==miopen.args.label)\
                                          .filter(miopen.dbt.job_table.state=='errored')\
                                          .filter(miopen.dbt.job_table.result.contains('%Find Compile: No results%'))\
                                          .count()
     #ommiting valid Fin/MIOpen errors
     num_jobs = num_jobs - valid_fin_err
     count = session.query(miopen.dbt.job_table).filter(miopen.dbt.job_table.session==miopen.args.session_id)\
+                                         .filter(miopen.dbt.job_table.reason==miopen.args.label)\
                                          .filter(miopen.dbt.job_table.state=='evaluated').count()
     assert count == num_jobs
 

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -232,7 +232,16 @@ def test_fin_evaluator():
 
   add_cfgs()
 
-  #add cfg for perf_eval
+  #run applicability
+  args = GoFishArgs()
+  machine_lst = load_machines(args)
+  miopen.args.update_applicability = True
+
+  worker_lst = miopen.compose_worker_list(machine_lst)
+  for worker in worker_lst:
+    worker.join()
+
+  #move cfg for perf_eval
   query1 = f"select count(*) from {dbt.config_tags_table.__tablename__} \
       where tag='tuna_pytest_fin_perf_eval';"
 
@@ -244,14 +253,6 @@ def test_fin_evaluator():
     if count == 0:
       session.execute(query2)
     session.commit()
-
-  args = GoFishArgs()
-  machine_lst = load_machines(args)
-  miopen.args.update_applicability = True
-
-  worker_lst = miopen.compose_worker_list(machine_lst)
-  for worker in worker_lst:
-    worker.join()
 
   #find_eval
   #load jobs

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -151,17 +151,18 @@ def test_fin_evaluator():
     worker.join()
 
   #load jobs
+  fin_step = 'miopen_perf_eval'
   args = LdJobArgs
   args.label = 'tuna_pytest_fin_eval'
   args.tag = 'tuna_pytest_fin_eval'
-  args.fin_steps = ['miopen_find_eval']
+  args.fin_steps = [fin_step]
   args.session_id = miopen.args.session_id
 
   logger = setup_logger('test_fin_evaluator')
   num_jobs = add_jobs(args, dbt, logger)
   assert num_jobs > 0
 
-  miopen.args.fin_steps = ["miopen_find_eval"]
+  miopen.args.fin_steps = [fin_step]
   miopen.args.label = 'tuna_pytest_fin_eval'
   miopen.fetch_state.add('new')
   miopen.operation = Operation.EVAL
@@ -226,7 +227,7 @@ def test_fin_evaluator():
                                          .filter(dbt.job_table.state=='evaluated').count()
     assert count == num_jobs
 
-  assert kwargs['fin_steps'] == ['miopen_find_eval']
+  assert kwargs['fin_steps'] == [fin_step]
 
   job_config = job_config_rows[0]
   job_dict, config_dict = serialize_job_config_row(job_config)
@@ -236,7 +237,7 @@ def test_fin_evaluator():
       [context['job'], context['config'], context['operation']])
   assert worker_kwargs['config']
   assert worker_kwargs['job']
-  assert worker_kwargs['fin_steps'] == ['miopen_find_eval']
+  assert worker_kwargs['fin_steps'] == [fin_step]
   fin_eval = get_worker(worker_kwargs, miopen.operation)
 
   #testing check_gpu

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -183,7 +183,9 @@ def test_fin_evaluator():
   fdb_attr.remove("insert_ts")
   fdb_attr.remove("update_ts")
 
-  tuning_data_attr = [column.name for column in inspect(miopen.dbt.tuning_data_table).c]
+  tuning_data_attr = [
+      column.name for column in inspect(miopen.dbt.tuning_data_table).c
+  ]
   tuning_data_attr.remove("insert_ts")
   tuning_data_attr.remove("update_ts")
 

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -125,50 +125,10 @@ def add_fake_fdb_entries(job_query, dbt, kernel_group):
     session.commit()
 
 
-def test_fin_evaluator():
-  miopen = MIOpen()
-  miopen.args = GoFishArgs()
-  machine_lst = load_machines(miopen.args)
-  machine = machine_lst[0]
-  miopen.args.label = 'tuna_pytest_fin_eval'
-  miopen.args.session_id = add_test_session(label='tuna_pytest_fin_eval')
-
-  #update solvers
-  kwargs = get_worker_args(miopen.args, machine, miopen)
-  fin_worker = FinClass(**kwargs)
-  assert fin_worker.get_solvers()
-
-  add_cfgs()
-  dbt = MIOpenDBTables(config_type=ConfigType.convolution,
-                       session_id=miopen.args.session_id)
-
-  args = GoFishArgs()
-  machine_lst = load_machines(args)
-  miopen.args.update_applicability = True
-
-  worker_lst = miopen.compose_worker_list(machine_lst)
-  for worker in worker_lst:
-    worker.join()
-
-  #load jobs
-  fin_step = 'miopen_find_eval'
-  args = LdJobArgs
-  args.label = 'tuna_pytest_fin_eval'
-  args.tag = 'tuna_pytest_fin_eval'
-  args.fin_steps = [fin_step]
-  args.session_id = miopen.args.session_id
-
-  logger = setup_logger('test_fin_evaluator')
-  num_jobs = add_jobs(args, dbt, logger)
-  assert num_jobs > 0
-
-  miopen.args.fin_steps = [fin_step]
-  miopen.args.label = 'tuna_pytest_fin_eval'
+def eval_step(machine, miopen, fin_step, num_jobs):
   miopen.fetch_state.add('new')
   miopen.operation = Operation.EVAL
   miopen.set_state = 'eval_start'
-  miopen.dbt = MIOpenDBTables(session_id=miopen.args.session_id,
-                              config_type=ConfigType.convolution)
   with DbSession() as session:
     jobs = miopen.get_jobs(session, miopen.fetch_state, miopen.set_state,
                            miopen.args.session_id)
@@ -212,29 +172,19 @@ def test_fin_evaluator():
     res_set.append((fin_json, context))
 
   with DbSession() as session:
-    #testing process_fin_evaluator results find_eval
+    #testing process_fin_evaluator results
     for fin_json, context in res_set:
       miopen.process_eval_results(session, fin_json, context)
 
-    valid_fin_err = session.query(dbt.job_table).filter(dbt.job_table.session==miopen.args.session_id)\
-                                         .filter(dbt.job_table.state=='errored')\
-                                         .filter(dbt.job_table.result.contains('%Find Compile: No results%'))\
+    valid_fin_err = session.query(miopen.dbt.job_table).filter(miopen.dbt.job_table.session==miopen.args.session_id)\
+                                         .filter(miopen.dbt.job_table.state=='errored')\
+                                         .filter(miopen.dbt.job_table.result.contains('%Find Compile: No results%'))\
                                          .count()
     #ommiting valid Fin/MIOpen errors
     num_jobs = num_jobs - valid_fin_err
-    count = session.query(dbt.job_table).filter(dbt.job_table.session==miopen.args.session_id)\
-                                         .filter(dbt.job_table.state=='evaluated').count()
+    count = session.query(miopen.dbt.job_table).filter(miopen.dbt.job_table.session==miopen.args.session_id)\
+                                         .filter(miopen.dbt.job_table.state=='evaluated').count()
     assert count == num_jobs
-
-  with DbSession() as session:
-    #testing process_fin_evaluator results perf_eval
-    fin_perf_json = copy.deepcopy(fin_json)
-    fin_perf_json['miopen_perf_eval_result'] = fin_perf_json[
-        'miopen_find_eval_result']
-    del fin_perf_json['miopen_find_eval_result']
-    for fin_json, context in res_set:
-      #testing process_fin_evaluator results
-      miopen.process_eval_results(session, fin_json, context)
 
   assert kwargs['fin_steps'] == [fin_step]
 
@@ -259,3 +209,76 @@ def test_fin_evaluator():
   find_eval_file = f"{this_path}/../utils/test_files/fin_output_find_eval.json"
   fin_json = json.loads(machine.read_file(find_eval_file))[1:]
   assert len(fin_json) == 1
+
+
+def test_fin_evaluator():
+  logger = setup_logger('test_fin_evaluator')
+  miopen = MIOpen()
+  miopen.args = GoFishArgs()
+  machine_lst = load_machines(miopen.args)
+  machine = machine_lst[0]
+  miopen.args.label = 'tuna_pytest_fin_eval'
+  miopen.args.session_id = add_test_session(label='tuna_pytest_fin_eval')
+  dbt = MIOpenDBTables(config_type=ConfigType.convolution,
+                       session_id=miopen.args.session_id)
+  miopen.dbt = dbt
+
+  #update solvers
+  kwargs = get_worker_args(miopen.args, machine, miopen)
+  fin_worker = FinClass(**kwargs)
+  assert fin_worker.get_solvers()
+
+  add_cfgs()
+
+  #add cfg for perf_eval
+  query1 = f"select count(*) from {dbt.config_tags_table.__tablename__} \
+      where tag='tuna_pytest_fin_perf_eval';"
+
+  query2 = f"update {dbt.config_tags_table.__tablename__} \
+      set tag='tuna_pytest_fin_perf_eval' where tag='tuna_pytest_fin_eval' order by config limit 1;"
+
+  with DbSession() as session:
+    count = session.execute(query1).fetchone()[0]
+    if count == 0:
+      session.execute(query2)
+    session.commit()
+
+  args = GoFishArgs()
+  machine_lst = load_machines(args)
+  miopen.args.update_applicability = True
+
+  worker_lst = miopen.compose_worker_list(machine_lst)
+  for worker in worker_lst:
+    worker.join()
+
+  #find_eval
+  #load jobs
+  fin_step = 'miopen_find_eval'
+  args = LdJobArgs
+  args.label = 'tuna_pytest_fin_eval'
+  args.tag = 'tuna_pytest_fin_eval'
+  args.fin_steps = [fin_step]
+  args.session_id = miopen.args.session_id
+  miopen.args.fin_steps = [fin_step]
+  miopen.args.label = args.label
+
+  num_jobs = add_jobs(args, dbt, logger)
+  assert num_jobs > 0
+
+  eval_step(machine, miopen, fin_step, num_jobs)
+
+  #perf_eval
+  #load jobs
+  fin_step = 'miopen_perf_eval'
+  args = LdJobArgs
+  args.label = 'tuna_pytest_fin_perf_eval'
+  args.tag = 'tuna_pytest_fin_perf_eval'
+  args.fin_steps = [fin_step]
+  args.session_id = miopen.args.session_id
+  miopen.args.fin_steps = [fin_step]
+  miopen.args.label = args.label
+
+  num_jobs = add_jobs(args, dbt, logger)
+  assert num_jobs > 0
+
+  eval_step(machine, miopen, fin_step, num_jobs)

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -229,7 +229,8 @@ def test_fin_evaluator():
   with DbSession() as session:
     #testing process_fin_evaluator results perf_eval
     fin_perf_json = copy.deepcopy(fin_json)
-    fin_perf_json['miopen_perf_eval_result'] = fin_perf_json['miopen_find_eval_result']
+    fin_perf_json['miopen_perf_eval_result'] = fin_perf_json[
+        'miopen_find_eval_result']
     del fin_perf_json['miopen_find_eval_result']
     for fin_json, context in res_set:
       #testing process_fin_evaluator results

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -229,8 +229,8 @@ def test_fin_evaluator():
   with DbSession() as session:
     #testing process_fin_evaluator results perf_eval
     fin_perf_json = copy.deepcopy(fin_json)
-    fin_perf_json['miopen_perf_eval'] = fin_perf_json['miopen_find_eval']
-    del fin_perf_json['miopen_find_eval']
+    fin_perf_json['miopen_perf_eval_result'] = fin_perf_json['miopen_find_eval_result']
+    del fin_perf_json['miopen_find_eval_result']
     for fin_json, context in res_set:
       #testing process_fin_evaluator results
       miopen.process_eval_results(session, fin_json, context)

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -151,7 +151,7 @@ def test_fin_evaluator():
     worker.join()
 
   #load jobs
-  fin_step = 'miopen_perf_eval'
+  fin_step = 'miopen_find_eval'
   args = LdJobArgs
   args.label = 'tuna_pytest_fin_eval'
   args.tag = 'tuna_pytest_fin_eval'
@@ -212,11 +212,10 @@ def test_fin_evaluator():
     res_set.append((fin_json, context))
 
   with DbSession() as session:
+    #testing process_fin_evaluator results find_eval
     for fin_json, context in res_set:
-      #testing process_fin_evaluator results
       miopen.process_eval_results(session, fin_json, context)
 
-  with DbSession() as session:
     valid_fin_err = session.query(dbt.job_table).filter(dbt.job_table.session==miopen.args.session_id)\
                                          .filter(dbt.job_table.state=='errored')\
                                          .filter(dbt.job_table.result.contains('%Find Compile: No results%'))\
@@ -226,6 +225,15 @@ def test_fin_evaluator():
     count = session.query(dbt.job_table).filter(dbt.job_table.session==miopen.args.session_id)\
                                          .filter(dbt.job_table.state=='evaluated').count()
     assert count == num_jobs
+
+  with DbSession() as session:
+    #testing process_fin_evaluator results perf_eval
+    fin_perf_json = copy.deepcopy(fin_json)
+    fin_perf_json['miopen_perf_eval'] = fin_perf_json['miopen_find_eval']
+    del fin_perf_json['miopen_find_eval']
+    for fin_json, context in res_set:
+      #testing process_fin_evaluator results
+      miopen.process_eval_results(session, fin_json, context)
 
   assert kwargs['fin_steps'] == [fin_step]
 

--- a/tests/test_fin_evaluator.py
+++ b/tests/test_fin_evaluator.py
@@ -183,6 +183,10 @@ def test_fin_evaluator():
   fdb_attr.remove("insert_ts")
   fdb_attr.remove("update_ts")
 
+  tuning_data_attr = [column.name for column in inspect(miopen.dbt.tuning_data_table).c]
+  tuning_data_attr.remove("insert_ts")
+  tuning_data_attr.remove("update_ts")
+
   res_set = []
   for elem in job_config_rows:
     job_dict, config_dict = serialize_job_config_row(elem)
@@ -193,7 +197,9 @@ def test_fin_evaluator():
         'arch': miopen.dbt.session.arch,
         'num_cu': miopen.dbt.session.num_cu,
         'kwargs': kwargs,
-        'fdb_attr': fdb_attr
+        'fdb_attr': fdb_attr,
+        'rich_data': True,
+        'tuning_data_attr': tuning_data_attr
     }
 
     worker = prep_worker(copy.deepcopy(context))

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -68,6 +68,7 @@ def add_job(w):
   #update solvers
   miopen = MIOpen()
   miopen.args = args
+  miopen.dbt = dbt
   kwargs = get_worker_args(args, machine, miopen)
   fin_worker = FinClass(**kwargs)
   assert (fin_worker.get_solvers())

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -73,9 +73,9 @@ def add_job(w):
   assert (fin_worker.get_solvers())
 
   #get applicability
-  args.update_applicability = True
-  args.label = 'tuna_pytest_worker'
-  args.session_id = w.session_id
+  miopen.args.update_applicability = True
+  miopen.args.label = 'tuna_pytest_worker'
+  miopen.args.session_id = w.session_id
   worker_lst = miopen.compose_worker_list(machine_lst)
   for worker in worker_lst:
     worker.join()

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -177,16 +177,16 @@ def test_worker():
   hostname = subp.stdout.readline().strip()
   machine = Machine(hostname=hostname, local_machine=True)
 
-  with DbSession() as session:
-    session.execute(f"delete from conv_job WHERE reason='tuna_pytest_worker'")
-    session.commit()
-
   keys = {}
   num_gpus = Value('i', 2)
   v = Value('i', 0)
   e = Value('i', 0)
 
-  session_id = add_test_session()
+  session_id = add_test_session(label='tuna_pytest_worker')
+
+  with DbSession() as session:
+    session.execute(f"delete from conv_job WHERE session={session_id}")
+    session.commit()
 
   keys = {
       'machine': machine,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -44,7 +44,6 @@ from tuna.miopen.utils.config_type import ConfigType
 from utils import get_worker_args, add_test_session
 from utils import CfgImportArgs, LdJobArgs, GoFishArgs
 from tuna.miopen.db.tables import MIOpenDBTables
-from tuna.utils.db_utility import connect_db
 from tuna.utils.logger import setup_logger
 from tuna.miopen.subcmd.import_configs import import_cfgs
 from tuna.miopen.subcmd.load_job import test_tag_name as tag_name_test, add_jobs
@@ -88,10 +87,9 @@ def add_job(w):
   args.fin_steps = ['not_fin']
   args.session_id = w.session_id
 
-  connect_db()
   if args.tag:
     try:
-      tag_name_test(args.tag, dbt)
+      assert tag_name_test(args.tag, dbt)
     except ValueError as terr:
       print(terr)
 

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -178,9 +178,7 @@ def test_worker():
   machine = Machine(hostname=hostname, local_machine=True)
 
   with DbSession() as session:
-    session.execute(
-      f"delete from conv_job WHERE reason='tuna_pytest_worker'"
-    )
+    session.execute(f"delete from conv_job WHERE reason='tuna_pytest_worker'")
     session.commit()
 
   keys = {}

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -39,6 +39,7 @@ from tuna.utils.machine_utility import load_machines
 from tuna.miopen.worker.fin_class import FinClass
 from tuna.machine import Machine
 from tuna.sql import DbCursor
+from tuna.dbBase.sql_alchemy import DbSession
 from tuna.miopen.utils.config_type import ConfigType
 from utils import get_worker_args, add_test_session
 from utils import CfgImportArgs, LdJobArgs, GoFishArgs
@@ -175,6 +176,12 @@ def test_worker():
   subp = Popen(cmd, stdout=PIPE, shell=True, universal_newlines=True)
   hostname = subp.stdout.readline().strip()
   machine = Machine(hostname=hostname, local_machine=True)
+
+  with DbSession() as session:
+    session.execute(
+      f"delete from conv_job WHERE reason='tuna_pytest_worker'"
+    )
+    session.commit()
 
   keys = {}
   num_gpus = Value('i', 2)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -125,6 +125,7 @@ class GoFishArgs():
   config_type = None
   reset_interval = None
   dynamic_solvers_only = False
+  rich_data = False
   label = 'pytest'
   docker_name = 'miopentuna'
   ticket = 'N/A'

--- a/tuna/machine.py
+++ b/tuna/machine.py
@@ -460,7 +460,7 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
     return False
 
   def chk_gpu_status(self, gpu_id: int) -> bool:
-    """check gpu status, can clinfo find the device"""
+    """check gpu status, can rocminfo find the device"""
     line: str
     stdout: StringIO = StringIO()
     logger: logging.Logger = self.get_logger()
@@ -472,7 +472,7 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
         return False
       logger.info('Checking GPU %u status', gpu_id)
       _, stdout, _ = cnx.exec_command(
-          f'GPU_DEVICE_ORDINAL={gpu_id} {CLINFO} | grep gfx', timeout=30)
+          f'ROCR_VISIBLE_DEVICES={gpu_id} {ROCMINFO} | grep gfx', timeout=30)
     else:
       logger.warning('No available gpus to check')
 
@@ -483,18 +483,18 @@ class Machine(BASE):  #pylint: disable=too-many-instance-attributes
         line = line.strip()
         logger.info(line)
         if line.find(f"{self.get_gpu(gpu_id)['arch']}") == -1:  #type: ignore
-          logger.warning('clinfo failed: %s', line)
-          logger.warning('clinfo failed for Device ID: %u', gpu_id)
+          logger.warning('rocminfo failed: %s', line)
+          logger.warning('rocminfo failed for Device ID: %u', gpu_id)
           return False
 
         logger.info('GPU %u status success', gpu_id)
         return True
       except (socket.timeout, socket.error) as error:
-        logger.warning('clinfo failed for Device ID: %u', gpu_id)
+        logger.warning('rocminfo failed for Device ID: %u', gpu_id)
         logger.warning('%s', error)
         return False
 
-    logger.warning('clinfo failed by default for Device ID: %u', gpu_id)
+    logger.warning('rocminfo failed by default for Device ID: %u', gpu_id)
     return False
 
   def getusedspace(self) -> float:

--- a/tuna/miopen/db/find_db.py
+++ b/tuna/miopen/db/find_db.py
@@ -143,6 +143,7 @@ class ConvolutionFindDB(BASE, FindDBMixin):  #pylint: disable=too-many-instance-
         'find_db')
     self.fdb_slv_dir = {}
 
+
 class ConvolutionTuningData(BASE, FindDBMixin):  #pylint: disable=too-many-instance-attributes
   """Concrete convolution find_db class"""
   __tablename__ = "conv_tuning_data"

--- a/tuna/miopen/db/find_db.py
+++ b/tuna/miopen/db/find_db.py
@@ -53,7 +53,7 @@ class FindDBMixin():  # pylint: disable=too-many-instance-attributes
     return Column(Integer, ForeignKey("solver.id"), nullable=False)
 
   fdb_key = Column(String(length=128), nullable=True)
-  params = Column(Text, nullable=False)
+  params = Column(String(length=512), nullable=False)
   kernel_time = Column(Float, nullable=False)
   workspace_sz = Column(BigInteger, nullable=False)
   alg_lib = Column(String(length=64), nullable=True)
@@ -136,6 +136,24 @@ class ConvolutionFindDB(BASE, FindDBMixin):  #pylint: disable=too-many-instance-
   config = Column(Integer, ForeignKey("conv_config.id"), nullable=False)
 
   kernel_group = Column(Integer, nullable=True)
+
+  @orm.reconstructor
+  def __init__(self, **kwargs):
+    self.logger = kwargs['logger'] if 'logger' in kwargs else setup_logger(
+        'find_db')
+    self.fdb_slv_dir = {}
+
+class ConvolutionTuningData(BASE, FindDBMixin):  #pylint: disable=too-many-instance-attributes
+  """Concrete convolution find_db class"""
+  __tablename__ = "conv_tuning_data"
+  __table_args__ = (UniqueConstraint("session",
+                                     "opencl",
+                                     "config",
+                                     "solver",
+                                     "params",
+                                     name="uq_idx"),)
+
+  config = Column(Integer, ForeignKey("conv_config.id"), nullable=False)
 
   @orm.reconstructor
   def __init__(self, **kwargs):

--- a/tuna/miopen/db/miopen_tables.py
+++ b/tuna/miopen/db/miopen_tables.py
@@ -26,7 +26,7 @@
 ###############################################################################
 """ Module for creating DB tables"""
 
-from tuna.miopen.db.find_db import BNFindDB, ConvolutionFindDB
+from tuna.miopen.db.find_db import BNFindDB, ConvolutionFindDB, ConvolutionTuningData
 from tuna.miopen.db.bn_golden_tables import BNGolden
 from tuna.miopen.db.fusion_config_tables import FusionConfig
 from tuna.miopen.db.fusion_config_tables import FusionConfigTags, FusionJob
@@ -59,6 +59,7 @@ def add_conv_tables(miopen_tables):
   miopen_tables.append(ConvJobCache())
   miopen_tables.append(ConvFinJobCache())
   miopen_tables.append(ConvolutionFindDB())
+  miopen_tables.append(ConvolutionTuningData())
   miopen_tables.append(ConvolutionGolden())
   miopen_tables.append(ConvSolverAnalyticsAggregated())
   miopen_tables.append(ConvSolverAnalyticsDetailed())

--- a/tuna/miopen/db/tables.py
+++ b/tuna/miopen/db/tables.py
@@ -63,6 +63,7 @@ class MIOpenDBTables(DBTablesInterface):
     self.config_table = None
     self.config_tags_table = None
     self.find_db_table = None
+    self.tuning_data_table = None
     self.solver_app = None
     self.cache_table = None
     self.fin_cache_table = None

--- a/tuna/miopen/db/tables.py
+++ b/tuna/miopen/db/tables.py
@@ -30,7 +30,7 @@ from tuna.miopen.db.batch_norm_tables import BNBenchmark, BNConfig
 from tuna.miopen.db.batch_norm_tables import BNConfigTags, BNFinJobCache
 from tuna.miopen.db.batch_norm_tables import BNJob, BNJobCache, BNKernelCache
 from tuna.miopen.db.batch_norm_tables import BNSolverApplicability
-from tuna.miopen.db.find_db import ConvolutionFindDB, BNFindDB
+from tuna.miopen.db.find_db import ConvolutionFindDB, BNFindDB, ConvolutionTuningData
 from tuna.miopen.db.convolutionjob_tables import ConvolutionJob
 from tuna.miopen.db.convolutionjob_tables import ConvolutionConfig
 from tuna.miopen.db.convolutionjob_tables import ConvolutionConfigTags
@@ -102,6 +102,7 @@ class MIOpenDBTables(DBTablesInterface):
       self.config_table = ConvolutionConfig
       self.config_tags_table = ConvolutionConfigTags
       self.find_db_table = ConvolutionFindDB
+      self.tuning_data_table = ConvolutionTuningData
       self.solver_app = ConvSolverApplicability
       self.cache_table = ConvJobCache
       self.fin_cache_table = ConvFinJobCache

--- a/tuna/miopen/miopen_lib.py
+++ b/tuna/miopen/miopen_lib.py
@@ -670,7 +670,9 @@ class MIOpen(MITunaInterface):
     @return tuning_data_attr tuning_data table attributes without timestamps
     """
     tuning_data_attr = None
-    tuning_data_attr = [column.name for column in inspect(self.dbt.tuning_data_table).c]
+    tuning_data_attr = [
+        column.name for column in inspect(self.dbt.tuning_data_table).c
+    ]
     tuning_data_attr.remove("insert_ts")
     tuning_data_attr.remove("update_ts")
     return tuning_data_attr
@@ -816,14 +818,14 @@ class MIOpen(MITunaInterface):
                                            result_str='miopen_perf_eval_result',
                                            check_str='evaluated')
             if context["rich_data"]:
-                status = process_tuning_data(session,
-                                            fin_json,
-                                            copy.deepcopy(context),
-                                            self.dbt,
-                                            context['tuning_data_attr'],
-                                            pending,
-                                            result_str='miopen_perf_eval_result',
-                                            check_str='evaluated')
+              status = process_tuning_data(session,
+                                           fin_json,
+                                           copy.deepcopy(context),
+                                           self.dbt,
+                                           context['tuning_data_attr'],
+                                           pending,
+                                           result_str='miopen_perf_eval_result',
+                                           check_str='evaluated')
 
         success, result_str = get_fin_result(status)
         failed_job = not success

--- a/tuna/miopen/miopen_lib.py
+++ b/tuna/miopen/miopen_lib.py
@@ -61,7 +61,7 @@ from tuna.miopen.db.triggers import drop_miopen_triggers, get_miopen_triggers
 from tuna.miopen.utils.config_type import ConfigType
 from tuna.miopen.db.tables import MIOpenDBTables
 #from tuna.miopen.celery_tuning.celery_tasks import celery_enqueue
-from tuna.miopen.utils.json_to_sql import process_fdb_w_kernels, process_pdb_compile
+from tuna.miopen.utils.json_to_sql import process_fdb_w_kernels, process_pdb_compile, process_tuning_data
 from tuna.miopen.utils.json_to_sql import clean_cache_table
 from tuna.miopen.utils.helper import set_job_state
 from tuna.miopen.worker.fin_utils import get_fin_result
@@ -136,6 +136,14 @@ class MIOpen(MITunaInterface):
         type=int,
         default=None,
         help='Limit the number of gpu workers created by Tuna, index from 0')
+
+    parser.add_argument(
+        '-R',
+        '--rich_data',
+        dest='rich_data',
+        action='store_true',
+        default=False,
+        help='record intermediate parameter results from perf tuning')
 
     subcommands = parser.add_subcommands(required=False)
     subcommands.add_subcommand('import_configs',
@@ -656,6 +664,17 @@ class MIOpen(MITunaInterface):
     fdb_attr.remove("update_ts")
     return fdb_attr
 
+  @lru_cache(1)
+  def get_tuning_data_attr(self):
+    """! Get tuning_data table attrs
+    @return tuning_data_attr tuning_data table attributes without timestamps
+    """
+    tuning_data_attr = None
+    tuning_data_attr = [column.name for column in inspect(self.dbt.tuning_data_table).c]
+    tuning_data_attr.remove("insert_ts")
+    tuning_data_attr.remove("update_ts")
+    return tuning_data_attr
+
   def serialize_jobs(self, session: DbSession, batch_jobs: List[Any]):
     """! Return list of serialize jobs
     @param session DB session
@@ -671,6 +690,7 @@ class MIOpen(MITunaInterface):
     context_list = []
     kwargs = self.get_context_items()
     fdb_attr = self.get_fdb_attr()
+    tuning_data_attr = self.get_tuning_data_attr()
     for job, config in serialized_jobs:
       context = {
           'job': job,
@@ -679,7 +699,9 @@ class MIOpen(MITunaInterface):
           'arch': self.dbt.session.arch,
           'num_cu': self.dbt.session.num_cu,
           'kwargs': kwargs,
-          'fdb_attr': fdb_attr
+          'rich_data': self.args.rich_data,
+          'fdb_attr': fdb_attr,
+          'tuning_data_attr': tuning_data_attr
       }
       context_list.append(context)
 
@@ -793,6 +815,15 @@ class MIOpen(MITunaInterface):
                                            pending,
                                            result_str='miopen_perf_eval_result',
                                            check_str='evaluated')
+            if context["rich_data"]:
+                status = process_tuning_data(session,
+                                            fin_json,
+                                            copy.deepcopy(context),
+                                            self.dbt,
+                                            context['tuning_data_attr'],
+                                            pending,
+                                            result_str='miopen_perf_eval_result',
+                                            check_str='evaluated')
 
         success, result_str = get_fin_result(status)
         failed_job = not success

--- a/tuna/miopen/miopen_lib.py
+++ b/tuna/miopen/miopen_lib.py
@@ -61,7 +61,8 @@ from tuna.miopen.db.triggers import drop_miopen_triggers, get_miopen_triggers
 from tuna.miopen.utils.config_type import ConfigType
 from tuna.miopen.db.tables import MIOpenDBTables
 #from tuna.miopen.celery_tuning.celery_tasks import celery_enqueue
-from tuna.miopen.utils.json_to_sql import process_fdb_w_kernels, process_pdb_compile, process_tuning_data
+from tuna.miopen.utils.json_to_sql import process_fdb_w_kernels, process_tuning_data
+from tuna.miopen.utils.json_to_sql import process_pdb_compile
 from tuna.miopen.utils.json_to_sql import clean_cache_table
 from tuna.miopen.utils.helper import set_job_state
 from tuna.miopen.worker.fin_utils import get_fin_result

--- a/tuna/miopen/utils/json_to_sql.py
+++ b/tuna/miopen/utils/json_to_sql.py
@@ -127,30 +127,26 @@ def __update_tuning_data(  #pylint: disable=too-many-arguments,too-many-locals
 
       if tuning_data_obj[check_str]:
         #returned entry is added to the table
-        tuning_data_entries = __compose_tuning_data_entries(session, fin_json, tuning_data_obj, session_id,
-                                        dbt, config, job, tuning_data_attr,
-                                        solver_id_map, pending)
+        tuning_data_entries = __compose_tuning_data_entries(
+            session, fin_json, tuning_data_obj, session_id, dbt, config, job,
+            tuning_data_attr, solver_id_map, pending)
 
         for tuning_data_entry in tuning_data_entries:
           __check_layout_mismatch(tuning_data_entry, slv_stat, config)
           if tuning_data_entry in pending:
             pending.remove(tuning_data_entry)
             query = gen_insert_query(tuning_data_entry, tuning_data_attr,
-                                    dbt.tuning_data_table.__tablename__)
+                                     dbt.tuning_data_table.__tablename__)
             session.execute(query)
           else:
             query = gen_update_query(tuning_data_entry, tuning_data_attr,
-                                    dbt.tuning_data_table.__tablename__)
+                                     dbt.tuning_data_table.__tablename__)
             session.execute(query)
       else:
         LOGGER.warning("Failed tuning_data update, cfg_id: %s, obj: %s",
                        fin_json['config_tuna_id'], tuning_data_obj)
   else:
-    status = [{
-        'solver': 'all',
-        'success': False,
-        'result': 'Eval: No results'
-    }]
+    status = [{'solver': 'all', 'success': False, 'result': 'Eval: No results'}]
 
   session.commit()
 
@@ -291,11 +287,12 @@ def get_fdb_entry(session, solver, session_id, dbt, config, fdb_attr):
   return obj, fdb_entry
 
 
-def __update_tuning_data_entry(session, solver, session_id, dbt, config, params, job, tuning_data_attr,
-                       pending):
+def __update_tuning_data_entry(session, solver, session_id, dbt, config, params,
+                               job, tuning_data_attr, pending):
   """ Add a new entry to fdb if there isnt one already """
-  obj, tuning_data_entry = get_tuning_data_entry(session, solver, session_id, dbt, config, params,
-                                 tuning_data_attr)
+  obj, tuning_data_entry = get_tuning_data_entry(session, solver, session_id,
+                                                 dbt, config, params,
+                                                 tuning_data_attr)
   if obj:  # existing entry in db
     # This can be removed if we implement the delete orphan cascade
     tuning_data_entry = obj
@@ -305,7 +302,8 @@ def __update_tuning_data_entry(session, solver, session_id, dbt, config, params,
   return tuning_data_entry
 
 
-def get_tuning_data_entry(session, solver, session_id, dbt, config, params, tuning_data_attr):
+def get_tuning_data_entry(session, solver, session_id, dbt, config, params,
+                          tuning_data_attr):
   """ Get FindDb entry from db """
   obj = None
   tuning_data_entry = None
@@ -315,8 +313,8 @@ def get_tuning_data_entry(session, solver, session_id, dbt, config, params, tuni
       f"params=\"{params}\"", "opencl=0"
   ]
   cond_str = f"where {' AND '.join(conds)}"
-  entries = gen_select_objs(session, tuning_data_attr, dbt.tuning_data_table.__tablename__,
-                            cond_str)
+  entries = gen_select_objs(session, tuning_data_attr,
+                            dbt.tuning_data_table.__tablename__, cond_str)
 
   if entries:
     assert len(entries) == 1
@@ -358,15 +356,16 @@ def __compose_fdb_entry(  #pylint: disable=too-many-arguments
 
 
 def __compose_tuning_data_entries(  #pylint: disable=too-many-arguments
-    session, fin_json, tuning_data_obj, session_id, dbt, config, job, tuning_data_attr,
-    solver_id_map, pending):
+    session, fin_json, tuning_data_obj, session_id, dbt, config, job,
+    tuning_data_attr, solver_id_map, pending):
   """Compose a FindDB table entry from fin_output"""
   solver = solver_id_map[tuning_data_obj['solver_name']]
 
   tuning_data_entries = []
   for item in tuning_data_obj['alt_solutions']:
-    entry = __update_tuning_data_entry(session, solver, session_id, dbt, config, item['params'], job,
-                                  tuning_data_attr, pending)
+    entry = __update_tuning_data_entry(session, solver, session_id, dbt, config,
+                                       item['params'], job, tuning_data_attr,
+                                       pending)
     entry.fdb_key = fin_json['db_key']
     entry.alg_lib = tuning_data_obj['algorithm']
     entry.workspace_sz = tuning_data_obj['workspace']
@@ -376,8 +375,9 @@ def __compose_tuning_data_entries(  #pylint: disable=too-many-arguments
     tuning_data_entries.append(entry)
 
   if not tuning_data_obj['alt_solutions']:
-    entry = __update_tuning_data_entry(session, solver, session_id, dbt, config, tuning_data_obj['params'], job,
-                                  tuning_data_attr, pending)
+    entry = __update_tuning_data_entry(session, solver, session_id, dbt, config,
+                                       tuning_data_obj['params'], job,
+                                       tuning_data_attr, pending)
     entry.fdb_key = fin_json['db_key']
     entry.alg_lib = tuning_data_obj['algorithm']
     entry.workspace_sz = tuning_data_obj['workspace']
@@ -421,13 +421,13 @@ def process_fdb_w_kernels(session,
 
 
 def process_tuning_data(session,
-                          fin_json,
-                          context,
-                          dbt,
-                          tuning_data_attr,
-                          pending,
-                          result_str='miopen_perf_eval_result',
-                          check_str='evaluated'):
+                        fin_json,
+                        context,
+                        dbt,
+                        tuning_data_attr,
+                        pending,
+                        result_str='miopen_perf_eval_result',
+                        check_str='evaluated'):
   """initiate find db update"""
   job = SimpleDict(**context['job'])
   config = SimpleDict(**context['config'])
@@ -436,7 +436,8 @@ def process_tuning_data(session,
   status = session_retry(
       session, callback,
       lambda x: x(session, fin_json, config, context['kwargs']['session_id'],
-                  dbt, job, tuning_data_attr, pending, result_str, check_str), LOGGER)
+                  dbt, job, tuning_data_attr, pending, result_str, check_str),
+      LOGGER)
 
   if not status:
     LOGGER.warning('Fin: Unable to update Database')

--- a/tuna/miopen/utils/json_to_sql.py
+++ b/tuna/miopen/utils/json_to_sql.py
@@ -106,6 +106,57 @@ def __update_fdb_w_kernels(  #pylint: disable=too-many-arguments,too-many-locals
   return status
 
 
+def __update_tuning_data(  #pylint: disable=too-many-arguments,too-many-locals
+    session: DbSession,
+    fin_json,
+    config,
+    session_id,
+    dbt,
+    job,
+    tuning_data_attr,
+    pending,
+    result_str: str = 'miopen_perf_eval_result',
+    check_str: str = 'evaluated') -> list:
+  """update tuning_data from json results"""
+  status = []
+  solver_id_map = get_solver_ids()
+  if result_str in fin_json.keys():
+    for tuning_data_obj in fin_json.get(result_str):
+      slv_stat = get_fin_slv_status(tuning_data_obj, check_str)
+      status.append(slv_stat)
+
+      if tuning_data_obj[check_str]:
+        #returned entry is added to the table
+        tuning_data_entries = __compose_tuning_data_entries(session, fin_json, tuning_data_obj, session_id,
+                                        dbt, config, job, tuning_data_attr,
+                                        solver_id_map, pending)
+
+        for tuning_data_entry in tuning_data_entries:
+          __check_layout_mismatch(tuning_data_entry, slv_stat, config)
+          if tuning_data_entry in pending:
+            pending.remove(tuning_data_entry)
+            query = gen_insert_query(tuning_data_entry, tuning_data_attr,
+                                    dbt.tuning_data_table.__tablename__)
+            session.execute(query)
+          else:
+            query = gen_update_query(tuning_data_entry, tuning_data_attr,
+                                    dbt.tuning_data_table.__tablename__)
+            session.execute(query)
+      else:
+        LOGGER.warning("Failed tuning_data update, cfg_id: %s, obj: %s",
+                       fin_json['config_tuna_id'], tuning_data_obj)
+  else:
+    status = [{
+        'solver': 'all',
+        'success': False,
+        'result': 'Eval: No results'
+    }]
+
+  session.commit()
+
+  return status
+
+
 def process_pdb_compile(session, fin_json, job, dbt, solver_id_map):
   """retrieve perf db compile json results"""
   status = []
@@ -240,6 +291,50 @@ def get_fdb_entry(session, solver, session_id, dbt, config, fdb_attr):
   return obj, fdb_entry
 
 
+def __update_tuning_data_entry(session, solver, session_id, dbt, config, params, job, tuning_data_attr,
+                       pending):
+  """ Add a new entry to fdb if there isnt one already """
+  obj, tuning_data_entry = get_tuning_data_entry(session, solver, session_id, dbt, config, params,
+                                 tuning_data_attr)
+  if obj:  # existing entry in db
+    # This can be removed if we implement the delete orphan cascade
+    tuning_data_entry = obj
+  else:
+    # Bundle Insert for later
+    pending.append(tuning_data_entry)
+  return tuning_data_entry
+
+
+def get_tuning_data_entry(session, solver, session_id, dbt, config, params, tuning_data_attr):
+  """ Get FindDb entry from db """
+  obj = None
+  tuning_data_entry = None
+
+  conds = [
+      f"session={session_id}", f"config={config.id}", f"solver={solver}",
+      f"params=\"{params}\"", "opencl=0"
+  ]
+  cond_str = f"where {' AND '.join(conds)}"
+  entries = gen_select_objs(session, tuning_data_attr, dbt.tuning_data_table.__tablename__,
+                            cond_str)
+
+  if entries:
+    assert len(entries) == 1
+    obj = entries[0]
+  else:
+    tuning_data_entry = SimpleDict()
+    for attr in tuning_data_attr:
+      setattr(tuning_data_entry, attr, None)
+    setattr(tuning_data_entry, 'session', session_id)
+    setattr(tuning_data_entry, 'opencl', False)
+    setattr(tuning_data_entry, 'config', config.id)
+    setattr(tuning_data_entry, 'solver', solver)
+    setattr(tuning_data_entry, 'params', params)
+    setattr(tuning_data_entry, 'logger', LOGGER)
+
+  return obj, tuning_data_entry
+
+
 def __compose_fdb_entry(  #pylint: disable=too-many-arguments
     session, fin_json, fdb_obj, session_id, dbt, config, job, fdb_attr,
     solver_id_map, pending):
@@ -262,6 +357,38 @@ def __compose_fdb_entry(  #pylint: disable=too-many-arguments
   return fdb_entry
 
 
+def __compose_tuning_data_entries(  #pylint: disable=too-many-arguments
+    session, fin_json, tuning_data_obj, session_id, dbt, config, job, tuning_data_attr,
+    solver_id_map, pending):
+  """Compose a FindDB table entry from fin_output"""
+  solver = solver_id_map[tuning_data_obj['solver_name']]
+
+  tuning_data_entries = []
+  for item in tuning_data_obj['alt_solutions']:
+    entry = __update_tuning_data_entry(session, solver, session_id, dbt, config, item['params'], job,
+                                  tuning_data_attr, pending)
+    entry.fdb_key = fin_json['db_key']
+    entry.alg_lib = tuning_data_obj['algorithm']
+    entry.workspace_sz = tuning_data_obj['workspace']
+    entry.valid = True
+    entry.params = item['params']
+    entry.kernel_time = item['time']
+    tuning_data_entries.append(entry)
+
+  if not tuning_data_obj['alt_solutions']:
+    entry = __update_tuning_data_entry(session, solver, session_id, dbt, config, tuning_data_obj['params'], job,
+                                  tuning_data_attr, pending)
+    entry.fdb_key = fin_json['db_key']
+    entry.alg_lib = tuning_data_obj['algorithm']
+    entry.workspace_sz = tuning_data_obj['workspace']
+    entry.valid = True
+    entry.params = tuning_data_obj['params']
+    entry.kernel_time = tuning_data_obj['time']
+    tuning_data_entries.append(entry)
+
+  return tuning_data_entries
+
+
 def process_fdb_w_kernels(session,
                           fin_json,
                           context,
@@ -281,6 +408,35 @@ def process_fdb_w_kernels(session,
       session, callback,
       lambda x: x(session, fin_json, config, context['kwargs']['session_id'],
                   dbt, job, fdb_attr, pending, result_str, check_str), LOGGER)
+
+  if not status:
+    LOGGER.warning('Fin: Unable to update Database')
+    status = [{
+        'solver': 'all',
+        'success': False,
+        'result': 'Fin: Unable to update Database'
+    }]
+
+  return status
+
+
+def process_tuning_data(session,
+                          fin_json,
+                          context,
+                          dbt,
+                          tuning_data_attr,
+                          pending,
+                          result_str='miopen_perf_eval_result',
+                          check_str='evaluated'):
+  """initiate find db update"""
+  job = SimpleDict(**context['job'])
+  config = SimpleDict(**context['config'])
+
+  callback = __update_tuning_data
+  status = session_retry(
+      session, callback,
+      lambda x: x(session, fin_json, config, context['kwargs']['session_id'],
+                  dbt, job, tuning_data_attr, pending, result_str, check_str), LOGGER)
 
   if not status:
     LOGGER.warning('Fin: Unable to update Database')

--- a/tuna/miopen/utils/json_to_sql.py
+++ b/tuna/miopen/utils/json_to_sql.py
@@ -127,21 +127,34 @@ def __update_tuning_data(  #pylint: disable=too-many-arguments,too-many-locals
 
       if tuning_data_obj[check_str]:
         #returned entry is added to the table
-        tuning_data_entries = __compose_tuning_data_entries(
-            session, fin_json, tuning_data_obj, session_id, dbt, config, job,
-            tuning_data_attr, solver_id_map, pending)
+        solver = solver_id_map[tuning_data_obj['solver_name']]
 
-        for tuning_data_entry in tuning_data_entries:
-          __check_layout_mismatch(tuning_data_entry, slv_stat, config)
-          if tuning_data_entry in pending:
-            pending.remove(tuning_data_entry)
-            query = gen_insert_query(tuning_data_entry, tuning_data_attr,
-                                     dbt.tuning_data_table.__tablename__)
-            session.execute(query)
-          else:
-            query = gen_update_query(tuning_data_entry, tuning_data_attr,
-                                     dbt.tuning_data_table.__tablename__)
-            session.execute(query)
+        for item in tuning_data_obj['alt_solutions']:
+          entry = __update_tuning_data_entry(session, solver, session_id, dbt,
+                                             config, item['params'], job,
+                                             tuning_data_attr, pending)
+          entry.fdb_key = fin_json['db_key']
+          entry.alg_lib = tuning_data_obj['algorithm']
+          entry.workspace_sz = tuning_data_obj['workspace']
+          entry.valid = True
+          entry.params = item['params']
+          entry.kernel_time = item['time']
+          __submit_tuning_data_entry(session, dbt, entry, tuning_data_attr,
+                                     slv_stat, config, pending)
+
+        if not tuning_data_obj['alt_solutions']:
+          entry = __update_tuning_data_entry(session, solver, session_id, dbt,
+                                             config, tuning_data_obj['params'],
+                                             job, tuning_data_attr, pending)
+          entry.fdb_key = fin_json['db_key']
+          entry.alg_lib = tuning_data_obj['algorithm']
+          entry.workspace_sz = tuning_data_obj['workspace']
+          entry.valid = True
+          entry.params = tuning_data_obj['params']
+          entry.kernel_time = tuning_data_obj['time']
+          __submit_tuning_data_entry(session, dbt, entry, tuning_data_attr,
+                                     slv_stat, config, pending)
+
       else:
         LOGGER.warning("Failed tuning_data update, cfg_id: %s, obj: %s",
                        fin_json['config_tuna_id'], tuning_data_obj)
@@ -355,38 +368,20 @@ def __compose_fdb_entry(  #pylint: disable=too-many-arguments
   return fdb_entry
 
 
-def __compose_tuning_data_entries(  #pylint: disable=too-many-arguments
-    session, fin_json, tuning_data_obj, session_id, dbt, config, job,
-    tuning_data_attr, solver_id_map, pending):
+def __submit_tuning_data_entry(  #pylint: disable=too-many-arguments
+    session, dbt, tuning_data_entry, tuning_data_attr, slv_stat, config,
+    pending):
   """Compose a FindDB table entry from fin_output"""
-  solver = solver_id_map[tuning_data_obj['solver_name']]
-
-  tuning_data_entries = []
-  for item in tuning_data_obj['alt_solutions']:
-    entry = __update_tuning_data_entry(session, solver, session_id, dbt, config,
-                                       item['params'], job, tuning_data_attr,
-                                       pending)
-    entry.fdb_key = fin_json['db_key']
-    entry.alg_lib = tuning_data_obj['algorithm']
-    entry.workspace_sz = tuning_data_obj['workspace']
-    entry.valid = True
-    entry.params = item['params']
-    entry.kernel_time = item['time']
-    tuning_data_entries.append(entry)
-
-  if not tuning_data_obj['alt_solutions']:
-    entry = __update_tuning_data_entry(session, solver, session_id, dbt, config,
-                                       tuning_data_obj['params'], job,
-                                       tuning_data_attr, pending)
-    entry.fdb_key = fin_json['db_key']
-    entry.alg_lib = tuning_data_obj['algorithm']
-    entry.workspace_sz = tuning_data_obj['workspace']
-    entry.valid = True
-    entry.params = tuning_data_obj['params']
-    entry.kernel_time = tuning_data_obj['time']
-    tuning_data_entries.append(entry)
-
-  return tuning_data_entries
+  __check_layout_mismatch(tuning_data_entry, slv_stat, config)
+  if tuning_data_entry in pending:
+    pending.remove(tuning_data_entry)
+    query = gen_insert_query(tuning_data_entry, tuning_data_attr,
+                             dbt.tuning_data_table.__tablename__)
+    session.execute(query)
+  else:
+    query = gen_update_query(tuning_data_entry, tuning_data_attr,
+                             dbt.tuning_data_table.__tablename__)
+    session.execute(query)
 
 
 def process_fdb_w_kernels(session,

--- a/tuna/miopen/worker/fin_class.py
+++ b/tuna/miopen/worker/fin_class.py
@@ -125,6 +125,12 @@ class FinClass(WorkerInterface):
     self.fdb_attr.remove("insert_ts")
     self.fdb_attr.remove("update_ts")
 
+    self.tuning_data_attr = [
+        column.name for column in inspect(self.dbt.tuning_data_table).c
+    ]
+    self.tuning_data_attr.remove("insert_ts")
+    self.tuning_data_attr.remove("update_ts")
+
   def get_miopen_v(self) -> str:
     """Interface function to get new branch hash"""
     commit_hash: str

--- a/tuna/miopen/worker/fin_class.py
+++ b/tuna/miopen/worker/fin_class.py
@@ -126,11 +126,11 @@ class FinClass(WorkerInterface):
     self.fdb_attr.remove("update_ts")
 
     if self.config_type == ConfigType.convolution:
-        self.tuning_data_attr = [
-            column.name for column in inspect(self.dbt.tuning_data_table).c
-        ]
-        self.tuning_data_attr.remove("insert_ts")
-        self.tuning_data_attr.remove("update_ts")
+      self.tuning_data_attr = [
+          column.name for column in inspect(self.dbt.tuning_data_table).c
+      ]
+      self.tuning_data_attr.remove("insert_ts")
+      self.tuning_data_attr.remove("update_ts")
 
   def get_miopen_v(self) -> str:
     """Interface function to get new branch hash"""

--- a/tuna/miopen/worker/fin_class.py
+++ b/tuna/miopen/worker/fin_class.py
@@ -125,11 +125,12 @@ class FinClass(WorkerInterface):
     self.fdb_attr.remove("insert_ts")
     self.fdb_attr.remove("update_ts")
 
-    self.tuning_data_attr = [
-        column.name for column in inspect(self.dbt.tuning_data_table).c
-    ]
-    self.tuning_data_attr.remove("insert_ts")
-    self.tuning_data_attr.remove("update_ts")
+    if self.config_type == ConfigType.convolution:
+        self.tuning_data_attr = [
+            column.name for column in inspect(self.dbt.tuning_data_table).c
+        ]
+        self.tuning_data_attr.remove("insert_ts")
+        self.tuning_data_attr.remove("update_ts")
 
   def get_miopen_v(self) -> str:
     """Interface function to get new branch hash"""

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -674,9 +674,9 @@ def pytestSuite3() {
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
-           //sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_worker.py -s"
-           //sh "python3 -m coverage run -a -m pytest tests/test_fin_evaluator.py -s"
-           //sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
+           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_worker.py -s"
+           sh "python3 -m coverage run -a -m pytest tests/test_fin_evaluator.py -s"
+           sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
         }
         sh "coverage report -m"
         archiveArtifacts ".coverage"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -624,6 +624,7 @@ def pytestSuite1() {
            // sh "pytest tests/test_mmi.py "
         }
         sh "coverage report -m "
+        archiveArtifacts ".coverage"
     }
 }
 
@@ -642,6 +643,7 @@ def pytestSuite2() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
+        sh "wget ${env.TUNA_COVERAGE_URL}/${env.branch}/${BUILD_ID}/artifact/.coverage"
         addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
@@ -651,6 +653,7 @@ def pytestSuite2() {
            sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_celery.py -s"
         }
         sh "coverage report -m"
+        archiveArtifacts ".coverage"
     }
 }
 
@@ -667,8 +670,8 @@ def pytestSuite3() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
+        sh "wget ${env.TUNA_COVERAGE_URL}/${env.branch}/${BUILD_ID}/artifact/.coverage"
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
-
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
            sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_worker.py -s"
@@ -676,6 +679,7 @@ def pytestSuite3() {
            sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
         }
         sh "coverage report -m"
+        archiveArtifacts ".coverage"
     }
 }
 
@@ -692,6 +696,7 @@ def Coverage(current_run, main_branch) {
         env.gateway_user = "${gateway_user}"
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
+        sh "wget ${env.TUNA_COVERAGE_URL}/${env.branch}/${BUILD_ID}/artifact/.coverage"
         sh "coverage report -m"
         sh "python3 -m coverage json"
         sh "coverage html"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -643,7 +643,7 @@ def pytestSuite2() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        sh "wget ${env.TUNA_COVERAGE_URL}/${env.branch}/${BUILD_ID}/artifact/.coverage"
+        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
         addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
@@ -670,7 +670,7 @@ def pytestSuite3() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        sh "wget ${env.TUNA_COVERAGE_URL}/${env.branch}/${BUILD_ID}/artifact/.coverage"
+        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
@@ -696,7 +696,7 @@ def Coverage(current_run, main_branch) {
         env.gateway_user = "${gateway_user}"
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
-        sh "wget ${env.TUNA_COVERAGE_URL}/${env.branch}/${BUILD_ID}/artifact/.coverage"
+        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
         sh "coverage report -m"
         sh "python3 -m coverage json"
         sh "coverage html"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -159,7 +159,6 @@ def finSolvers(){
 def finApplicability(){
     def tuna_docker = getDocker("HIP")
     tuna_docker.inside("--network host  --dns 8.8.8.8 ${docker_args}") {
-        checkout scm
         env.TUNA_DB_HOSTNAME = "${db_host}"
         env.TUNA_DB_NAME="${db_name}"
         env.TUNA_DB_USER_NAME="${db_user}"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -578,7 +578,7 @@ def perfEval() {
 
 def pytestSuite1() {
     def tuna_docker = getDocker("HIP")
-    tuna_docker.inside("--network host  --dns 8.8.8.8") {
+    tuna_docker.inside("--network host --dns 8.8.8.8 ${docker_args} ") {
         env.TUNA_DB_HOSTNAME = "${db_host}"
         env.TUNA_CELERY_BROKER_HOST = "${db_host}"
         env.TUNA_CELERY_BACKEND_HOST = "${db_host}"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -570,7 +570,7 @@ def perfEval() {
         if(golden_entries.toInteger() != fdb_entries.toInteger())
         {
             echo "#fdb jobs: ${fdb_entries}"
-            echo "#goden jobs: ${golden_entries}"
+            echo "#golden jobs: ${golden_entries}"
             error("FDB entries and golden entries do not match")
         }
     }
@@ -643,7 +643,8 @@ def pytestSuite2() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        sh "wget ${BUILD_URL}/artifact/.coverage"
+        #sh "wget ${BUILD_URL}/artifact/.coverage"
+        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
         addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
@@ -670,7 +671,8 @@ def pytestSuite3() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        sh "wget ${BUILD_URL}/artifact/.coverage"
+        #sh "wget ${BUILD_URL}/artifact/.coverage"
+        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
@@ -696,7 +698,8 @@ def Coverage(current_run, main_branch) {
         env.gateway_user = "${gateway_user}"
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
-        sh "wget ${BUILD_URL}/artifact/.coverage"
+        #sh "wget ${BUILD_URL}/artifact/.coverage"
+        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
         sh "coverage report -m"
         sh "python3 -m coverage json"
         sh "coverage html"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -643,7 +643,7 @@ def pytestSuite2() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
+        copyArtifacts ".coverage"
         addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
@@ -670,7 +670,7 @@ def pytestSuite3() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
+        copyArtifacts ".coverage"
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
@@ -696,7 +696,7 @@ def Coverage(current_run, main_branch) {
         env.gateway_user = "${gateway_user}"
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
-        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
+        copyArtifacts ".coverage"
         sh "coverage report -m"
         sh "python3 -m coverage json"
         sh "coverage html"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -577,8 +577,8 @@ def perfEval() {
 }
 
 def pytestSuite1() {
-    def tuna_docker = getDocker("HIP")
-    tuna_docker.inside("--network host --dns 8.8.8.8 ${docker_args} ") {
+    def tuna_docker = getDocker("HIPNOGPU")
+    tuna_docker.inside("--network host  --dns 8.8.8.8 ") {
         env.TUNA_DB_HOSTNAME = "${db_host}"
         env.TUNA_CELERY_BROKER_HOST = "${db_host}"
         env.TUNA_CELERY_BACKEND_HOST = "${db_host}"
@@ -622,20 +622,12 @@ def pytestSuite1() {
            sh "python3 -m coverage run -a -m pytest tests/test_mituna_interface.py -s"
            // The OBMC host used in the following test is down
            // sh "pytest tests/test_mmi.py "
-           // test fin builder and test fin builder conv in sequence
-           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_worker.py -s"
-           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_fin_builder.py -s"
-           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_celery.py -s"
-	   //test evaluation
-           sh "python3 -m coverage run -a -m pytest tests/test_fin_evaluator.py -s"
-           sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
         }
         sh "coverage report -m "
     }
 }
 
 
-/*
 def pytestSuite2() {
     def tuna_docker = getDocker("HIPNOGPU")
     tuna_docker.inside("--network host  --dns 8.8.8.8 ") {
@@ -654,6 +646,9 @@ def pytestSuite2() {
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
         sshagent (credentials: ['bastion-ssh-key']) {
+           // test fin builder and test fin builder conv in sequence
+           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_fin_builder.py -s"
+           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_celery.py -s"
         }
         sh "coverage report -m"
     }
@@ -675,11 +670,14 @@ def pytestSuite3() {
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
 
         sshagent (credentials: ['bastion-ssh-key']) {
+	   //test evaluation
+           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_worker.py -s"
+           sh "python3 -m coverage run -a -m pytest tests/test_fin_evaluator.py -s"
+           sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
         }
         sh "coverage report -m"
     }
 }
-*/
 
 
 def Coverage(current_run, main_branch) {

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -674,9 +674,9 @@ def pytestSuite3() {
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
-           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_worker.py -s"
-           sh "python3 -m coverage run -a -m pytest tests/test_fin_evaluator.py -s"
-           sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
+           //sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_worker.py -s"
+           //sh "python3 -m coverage run -a -m pytest tests/test_fin_evaluator.py -s"
+           //sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
         }
         sh "coverage report -m"
         archiveArtifacts ".coverage"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -577,7 +577,7 @@ def perfEval() {
 }
 
 def pytestSuite1() {
-    def tuna_docker = getDocker("HIPNOGPU")
+    def tuna_docker = getDocker("HIP")
     tuna_docker.inside("--network host  --dns 8.8.8.8") {
         env.TUNA_DB_HOSTNAME = "${db_host}"
         env.TUNA_DB_NAME="${db_name}"
@@ -620,12 +620,20 @@ def pytestSuite1() {
            sh "python3 -m coverage run -a -m pytest tests/test_mituna_interface.py -s"
            // The OBMC host used in the following test is down
            // sh "pytest tests/test_mmi.py "
+           // test fin builder and test fin builder conv in sequence
+           sh "python3 -m coverage run -a -m pytest tests/test_worker.py -s"
+           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_fin_builder.py -s"
+           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_celery.py -s"
+	   //test evaluation
+           sh "python3 -m coverage run -a -m pytest tests/test_fin_evaluator.py -s"
+           sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
         }
         sh "coverage report -m "
     }
 }
 
 
+/*
 def pytestSuite2() {
     def tuna_docker = getDocker("HIPNOGPU")
     tuna_docker.inside("--network host  --dns 8.8.8.8 ") {
@@ -644,10 +652,6 @@ def pytestSuite2() {
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
         sshagent (credentials: ['bastion-ssh-key']) {
-           // test fin builder and test fin builder conv in sequence
-           sh "python3 -m coverage run -a -m pytest tests/test_worker.py -s"
-           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_fin_builder.py -s"
-           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_celery.py -s"
         }
         sh "coverage report -m"
     }
@@ -669,12 +673,11 @@ def pytestSuite3() {
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
 
         sshagent (credentials: ['bastion-ssh-key']) {
-           sh "python3 -m coverage run -a -m pytest tests/test_fin_evaluator.py -s"
-           sh "python3 -m coverage run -a -m pytest tests/test_update_golden.py -s"
         }
         sh "coverage report -m"
     }
 }
+*/
 
 
 def Coverage(current_run, main_branch) {

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -580,6 +580,8 @@ def pytestSuite1() {
     def tuna_docker = getDocker("HIP")
     tuna_docker.inside("--network host  --dns 8.8.8.8") {
         env.TUNA_DB_HOSTNAME = "${db_host}"
+        env.TUNA_CELERY_BROKER_HOST = "${db_host}"
+        env.TUNA_CELERY_BACKEND_HOST = "${db_host}"
         env.TUNA_DB_NAME="${db_name}"
         env.TUNA_DB_USER_NAME="${db_user}"
         env.TUNA_DB_USER_PASSWORD="${db_password}"
@@ -621,7 +623,7 @@ def pytestSuite1() {
            // The OBMC host used in the following test is down
            // sh "pytest tests/test_mmi.py "
            // test fin builder and test fin builder conv in sequence
-           sh "python3 -m coverage run -a -m pytest tests/test_worker.py -s"
+           sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_worker.py -s"
            sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_fin_builder.py -s"
            sh "TUNA_LOGLEVEL=INFO python3 -m coverage run -a -m pytest tests/test_celery.py -s"
 	   //test evaluation

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -643,8 +643,7 @@ def pytestSuite2() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        //sh "wget ${BUILD_URL}/artifact/.coverage"
-        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
+        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), filter: ".coverage")
         addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
@@ -671,8 +670,7 @@ def pytestSuite3() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        //sh "wget ${BUILD_URL}/artifact/.coverage"
-        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
+        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), filter: ".coverage")
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
@@ -698,8 +696,7 @@ def Coverage(current_run, main_branch) {
         env.gateway_user = "${gateway_user}"
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
-        //sh "wget ${BUILD_URL}/artifact/.coverage"
-        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
+        copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), filter: ".coverage")
         sh "coverage report -m"
         sh "python3 -m coverage json"
         sh "coverage html"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -643,7 +643,7 @@ def pytestSuite2() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        #sh "wget ${BUILD_URL}/artifact/.coverage"
+        //sh "wget ${BUILD_URL}/artifact/.coverage"
         copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
         addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         // download the latest perf db
@@ -671,7 +671,7 @@ def pytestSuite3() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        #sh "wget ${BUILD_URL}/artifact/.coverage"
+        //sh "wget ${BUILD_URL}/artifact/.coverage"
         copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
@@ -698,7 +698,7 @@ def Coverage(current_run, main_branch) {
         env.gateway_user = "${gateway_user}"
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
-        #sh "wget ${BUILD_URL}/artifact/.coverage"
+        //sh "wget ${BUILD_URL}/artifact/.coverage"
         copyArtifacts(projectName: "${JOB_NAME}", selector: specific("${BUILD_NUMBER}"), artifacts: ".coverage")
         sh "coverage report -m"
         sh "python3 -m coverage json"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -643,7 +643,7 @@ def pytestSuite2() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        copyArtifacts ".coverage"
+        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
         addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
@@ -670,7 +670,7 @@ def pytestSuite3() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        copyArtifacts ".coverage"
+        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
@@ -696,7 +696,7 @@ def Coverage(current_run, main_branch) {
         env.gateway_user = "${gateway_user}"
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
-        copyArtifacts ".coverage"
+        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
         sh "coverage report -m"
         sh "python3 -m coverage json"
         sh "coverage html"

--- a/vars/utils.groovy
+++ b/vars/utils.groovy
@@ -643,7 +643,7 @@ def pytestSuite2() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
+        sh "wget ${BUILD_URL}/artifact/.coverage"
         addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         // download the latest perf db
         //runsql("DELETE FROM config_tags; DELETE FROM job; DELETE FROM config;")
@@ -670,7 +670,7 @@ def pytestSuite3() {
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
 
-        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
+        sh "wget ${BUILD_URL}/artifact/.coverage"
         //addMachine(arch, num_cu, machine_ip, machine_local_ip, username, pwd, port)
         sshagent (credentials: ['bastion-ssh-key']) {
 	   //test evaluation
@@ -696,7 +696,7 @@ def Coverage(current_run, main_branch) {
         env.gateway_user = "${gateway_user}"
         env.PYTHONPATH=env.WORKSPACE
         env.PATH="${env.WORKSPACE}/tuna:${env.PATH}"
-        sh "wget ${env.TUNA_COVERAGE_URL}/${scm.branches[0].name}/${BUILD_ID}/artifact/.coverage"
+        sh "wget ${BUILD_URL}/artifact/.coverage"
         sh "coverage report -m"
         sh "python3 -m coverage json"
         sh "coverage html"


### PR DESCRIPTION
## Motivation

Enable collection + storage of multiple perf parameter results per config + solver

## Technical Details

Added additional table ConvolutionTuningData to function like ConvolutionFindDB except with params as an additional condition for uniqueness. 
Added update methods to store fin results to this table.
Added --rich_data as an option to be ran with go_fish enqueue to store results to the new table.

## Test

Ran on 50 configurations with Tunable and Non-Tunable solvers. Population of the ConvolutionFindDB table was unaffected. Population of the ConvolutionTuningData table was successful for both types of solvers.
