### PR TITLE
Set default value of causal, return_lse and with-attn-* to false

### DIFF
--- a/tuna/rocmlir/rocmlir_tables.py
+++ b/tuna/rocmlir/rocmlir_tables.py
@@ -742,7 +742,7 @@ class AttentionConfig(BASE, SimpleCSVMixin):
       for datatype, transQ, transK, transV, transO, withAttnScale, withAttnBias, causal, return_lse, line in \
               itertools.product(['f32', 'f16'], ['false', 'true'],
                                 ['false', 'true'], ['false', 'true'],
-                                ['false', 'true'], ['false', 'true'], ['false', 'true'], ['false', 'true'], ['false', 'true'], lines):
+                                ['false', 'true'], ['false'], ['false'], ['false'], ['false'], lines):
         line = line.strip()
 
         # Skip empty lines


### PR DESCRIPTION
## Motivation

To avoid really long tuning time, we can set the default value of these params to false. I think if migraphx didn't provide those, it's a safe assumption that they are false.

## Technical Details

Just set the value to false if they are not in the problem config.

## Test Plan

All tests pass.

## Test Result

All tests pass.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
