### PR TITLE
Ignore unnecessary tuning output fields

### DIFF
--- a/tuna/rocmlir/rocmlir_worker.py
+++ b/tuna/rocmlir/rocmlir_worker.py
@@ -71,7 +71,7 @@ class RocMLIRWorker(WorkerInterface):
     """update results table with individual result entry"""
     obj = self.dbt.results()
 
-    arch, num_cu, num_chiplets, config, perf_config, tflops = obj.parse(result_str)
+    arch, num_cu, num_chiplets, config, perf_config, tflops = obj.parse(result_str)[:6]
 
     print(f"arch = '{arch}', num_cu = '{num_cu}', num_chiplets = '{num_chiplets}', config = '{config}', \
           perf_config = '{perf_config}', tflops = {tflops}",


### PR DESCRIPTION
## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->
There were changes to the tuning output with additional fields added in https://github.com/ROCm/rocMLIR/pull/2208. MITuna doesn't care about the new fields since they are metadata.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->
Ignore any extra fields after the ones we need.

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
